### PR TITLE
feat: pass HTML attributes to select choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pass HTML attributes to select choices
+
 ## [0.1.2] - 2023-07-31
 
 ### Changed

--- a/app/components/impulse/select_component.html.erb
+++ b/app/components/impulse/select_component.html.erb
@@ -5,7 +5,7 @@
     <% end %>
   <% else %>
     <% options_from_choices.each do |option| %>
-      <%= c.with_option(value: option.value, text: option.text) %>
+      <%= c.with_option(value: option.value, text: option.text, **option.html_attributes) %>
     <% end %>
   <% end %>
 

--- a/app/components/impulse/select_component.rb
+++ b/app/components/impulse/select_component.rb
@@ -3,6 +3,8 @@ module Impulse
     renders_one :blankslate
     renders_many :options, Impulse::Autocomplete::OptionComponent
 
+    OptionStruct = Struct.new(:value, :text, :html_attributes)
+
     def initialize(object_name, method_name, choices = [], selected: nil, **system_args)
       @object_name = object_name
       @method_name = method_name
@@ -22,8 +24,9 @@ module Impulse
     def options_from_choices
       return [] if @choices.nil?
       @choices.map do |choice|
-        tuple = option_text_and_value(choice)
-        OpenStruct.new(value: tuple.last, text: tuple.first)
+        html_attributes = option_html_attributes(choice)
+        text, value = option_text_and_value(choice)
+        OptionStruct.new(value, text, html_attributes)
       end
     end
 

--- a/test/components/select_component_test.rb
+++ b/test/components/select_component_test.rb
@@ -18,10 +18,18 @@ module Impulse
     end
 
     test "renders options from a pair of choices" do
-      render_inline(Impulse::SelectComponent.new(:user, :fruit_id, [["Apple", "apple"]]))
+      render_inline(Impulse::SelectComponent.new(:user, :fruit_id, [["Apple", "apple"], ["Banana", "banana", {disabled: true, class: "custom-class"}]]))
 
       assert_selector "[role='option'][value='apple']", visible: false
       assert_selector "[role='option'][data-text='Apple']", visible: false
+      assert_selector ".custom-class[role='option'][value='banana'][data-text='Banana'][disabled]", visible: false
+    end
+
+    test "renders options from a hash" do
+      render_inline(Impulse::SelectComponent.new(:user, :fruit_id, {Basic: "$20", Plus: "$40"}))
+
+      assert_selector "[role='option'][value='$20'][data-text='Basic']", visible: false
+      assert_selector "[role='option'][value='$40'][data-text='Plus']", visible: false
     end
 
     test "renders options from a block" do


### PR DESCRIPTION
```erb
<%= render(Impulse::SelectComponent.new(:user, :fruit_id, [["Apple", "apple", { disabled: true }]]) %>
```