### PR TITLE
fix: set `initialClickTarget` to `null` when destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set `initialClickTarget` to `null` when element gets destroyed
+
 ## [0.1.3] - 2023-08-03
 
 ### Added

--- a/src/hooks/use_outside_click.ts
+++ b/src/hooks/use_outside_click.ts
@@ -40,6 +40,7 @@ export default function useOutsideClick(
   document.addEventListener('click', (event) => handleOutsideClick(event, () => initialClickTarget), true);
 
   function destroy() {
+    initialClickTarget = null;
     document.removeEventListener('mousedown', setInitialClickTarget, true);
     document.removeEventListener('click', (event) => handleOutsideClick(event, () => initialClickTarget), true);
   }


### PR DESCRIPTION
fixes #15