### PR TITLE
fix: only prevent outside click event if target is not focusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove overflow and padding when dialog is closed via escape key
+- Only prevent outside click event if target is not focusable
 
 ### Added
 

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -3,6 +3,7 @@ import { ImpulseElement, property, registerElement, target, targets } from '@amb
 import debounce from 'src/helpers/debounce';
 import useFloatingUI, { UseFloatingUIType } from 'src/hooks/use_floating_ui';
 import useOutsideClick from 'src/hooks/use_outside_click';
+import { isFocusable } from 'tabbable';
 import { getText, getValue } from './helpers';
 import MultipleSelect from './multiple_select';
 import SingleSelect from './single_select';
@@ -81,10 +82,10 @@ export default class AwcAutocompleteElement extends ImpulseElement {
     });
     useOutsideClick(this, {
       boundaries: [this.control, this.listbox],
-      callback: (event: Event) => {
+      callback: (event: Event, target: HTMLElement) => {
         // Since the blur event fires before the click event, we need to conditionally prevent the event so that the
         // dialog element remains open when there are nested autocomplete elements inside it which are still open.
-        if (this.inputPristine) {
+        if (this.inputPristine && !isFocusable(target)) {
           event.preventDefault();
         } else if (this.open) {
           this.open = false;

--- a/src/elements/popover/index.ts
+++ b/src/elements/popover/index.ts
@@ -4,6 +4,7 @@ import focusTrap from 'src/helpers/focus_trap';
 import useFloatingUI, { UseFloatingUIType } from 'src/hooks/use_floating_ui';
 import useOutsideClick from 'src/hooks/use_outside_click';
 import { stripCSSUnit } from '../../helpers/string';
+import { isFocusable } from 'tabbable';
 
 @registerElement('awc-popover')
 export default class AwcPopoverElement extends ImpulseElement {
@@ -45,10 +46,13 @@ export default class AwcPopoverElement extends ImpulseElement {
 
     useOutsideClick(this, {
       boundaries: this.boundaries,
-      callback: (event: Event) => {
+      callback: (event: Event, target: HTMLElement) => {
         if (this.open) {
-          event.preventDefault();
           this.open = false;
+          // Prevent modals from closing accidentally.
+          if (!isFocusable(target)) {
+            event.preventDefault();
+          }
         }
       },
     });


### PR DESCRIPTION
fixes #30 