### PR TITLE
feat: add focus and blur methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `PopoverComponent`
+- Add `focus` and `blur` methods to the autocomplete element
 
 ## [0.2.1] - 2023-08-22
 

--- a/docs/js-api/autocomplete.md
+++ b/docs/js-api/autocomplete.md
@@ -91,6 +91,22 @@ Resets the autocomplete value to its initial state.
 autocomplete.reset();
 ```
 
+### `focus`
+
+Sets the focus on the input element. This method also accepts a list of focus [options](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#parameters).
+
+```js
+autocomplete.focus();
+```
+
+### `blur`
+
+Removes keyboard focus from the input element.
+
+```js
+autocomplete.blur();
+```
+
 ### `activeOption`
 
 Returns the option that has the `data-active` attribute.

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -360,6 +360,23 @@ export default class AwcAutocompleteElement extends ImpulseElement {
     this.currentQuery = undefined;
   }
 
+  /**
+   * Sets the focus on the input element.
+   * @param options - https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#parameters
+   */
+  focus(options?: FocusOptions) {
+    // Do not add the `data-focus` attribute. Behave like a native input element.
+    this.input.focus(options);
+  }
+
+  /**
+   * Removes keyboard focus from the input element.
+   */
+  blur() {
+    this.input.blur();
+    this.removeAttribute('data-focus');
+  }
+
   private search(query: string) {
     this.open = true;
     this.options.forEach(filterOptions(query));


### PR DESCRIPTION
## Usage

```js
autocomplete.focus();
autocomplete.blur();
```

closes #34 