### PR TITLE
feat(autocomplete): add `show` and `hide` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `PopoverComponent`
 - Add `focus` and `blur` methods to the autocomplete element
+- Add `show` and `hide` methods to the autocomplete element
 
 ## [0.2.1] - 2023-08-22
 

--- a/docs/js-api/autocomplete.md
+++ b/docs/js-api/autocomplete.md
@@ -15,14 +15,20 @@ autocomplete.open;
 // => false
 ```
 
-### `open=`
+### `show`
 
-Shows/hides the listbox.
+Shows the listbox.
 
 ```js
-autocomplete.open = true;
-autocomplete.open;
-// => true;
+autocomplete.show();
+```
+
+### `hide`
+
+Hides the listbox.
+
+```js
+autocomplete.hide();
 ```
 
 ### `value`

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -377,6 +377,22 @@ export default class AwcAutocompleteElement extends ImpulseElement {
     this.removeAttribute('data-focus');
   }
 
+  /**
+   * Shows the listbox.
+   */
+  show() {
+    if (this.open) return;
+    this.open = true;
+  }
+
+  /**
+   * Hides the listbox.
+   */
+  hide() {
+    if (!this.open) return;
+    this.open = false;
+  }
+
   private search(query: string) {
     this.open = true;
     this.options.forEach(filterOptions(query));


### PR DESCRIPTION
This API makes it consistent with the popover element.
```js
autocomplete.show() // Shows the listbox
autocomplete.hide() // Hides the listbox
```