### PR TITLE
fix(popover): focus trigger when user interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Only hide the last opened popover when clicking outside if there are multiple nested popovers
+- Focus popover trigger element when event is initiated via user interaction
 
 ## [0.2.3] - 2023-09-12
 

--- a/src/elements/popover/index.ts
+++ b/src/elements/popover/index.ts
@@ -59,6 +59,7 @@ export default class AwcPopoverElement extends ImpulseElement {
           // Prevent modals from closing accidentally.
           if (!isFocusable(target)) {
             event.preventDefault();
+            this.button.focus();
           }
         }
       },
@@ -101,7 +102,11 @@ export default class AwcPopoverElement extends ImpulseElement {
   }
 
   toggle() {
-    this.open = !this.open;
+    if (this.open) {
+      this.hide();
+    } else {
+      this.show();
+    }
   }
 
   show() {
@@ -119,6 +124,11 @@ export default class AwcPopoverElement extends ImpulseElement {
 
     if (!this.open) return;
     this.open = false;
+
+    // This event originated from a button click.
+    if (event) {
+      this.button.focus();
+    }
   }
 
   handleKeydown(event: KeyboardEvent) {
@@ -132,6 +142,7 @@ export default class AwcPopoverElement extends ImpulseElement {
           event.preventDefault();
           event.stopPropagation();
           this.open = false;
+          this.button.focus();
         }
         break;
       }

--- a/src/helpers/focus_trap.test.ts
+++ b/src/helpers/focus_trap.test.ts
@@ -108,7 +108,7 @@ describe('focus_trap', () => {
     expect(document.activeElement).to.equal(button2);
 
     nestedTrap.abort();
-    expect(document.activeElement).to.equal(button1);
+    button1.focus();
 
     await sendKeys({ press: 'Tab' });
     expect(document.activeElement).to.equal(button2);
@@ -156,7 +156,7 @@ describe('focus_trap', () => {
     expect(document.activeElement).to.equal(button3);
 
     trap2.abort();
-    expect(document.activeElement).to.equal(button1);
+    button1.focus();
 
     await sendKeys({ press: 'Tab' });
     expect(document.activeElement).to.equal(button2);

--- a/src/helpers/focus_trap.ts
+++ b/src/helpers/focus_trap.ts
@@ -11,7 +11,6 @@ export default function focusTrap(
   const controller = new AbortController();
   const signal = abortSignal || controller.signal;
 
-  let focusedElementBeforeActivation: HTMLElement | null = document.activeElement as HTMLElement;
   let recentlyFocused: HTMLElement | FocusableElement | null;
 
   // TODO: Remove this once ambiki migrates to dialog component.
@@ -65,8 +64,6 @@ export default function focusTrap(
     sentinels?.forEach((sentinel) => sentinel.remove());
 
     containerStack.delete(container);
-    tryFocus(focusedElementBeforeActivation);
-    focusedElementBeforeActivation = null;
     recentlyFocused = null;
   });
 


### PR DESCRIPTION
Calling `hide` method on the popover element via js should not focus on the trigger element. Trigger element should only be focused when popovers are hidden via user interaction.