### PR TITLE
fix: remove `data-focus-trap-id` attribute after releasing the focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only hide the last opened popover when clicking outside if there are multiple nested popovers
 - Focus popover trigger element when event is initiated via user interaction
 - Loosely look for focusable elements when clicking outside
+- Remove `data-focus-trap-id` attribute from the container after releasing the focus trap
 
 ## [0.2.3] - 2023-09-12
 

--- a/src/helpers/focus_trap.test.ts
+++ b/src/helpers/focus_trap.test.ts
@@ -17,6 +17,7 @@ describe('focus_trap', () => {
     focusTrap(container);
 
     expect(document.activeElement).to.equal(container.querySelector('button'));
+    expect(container).to.have.attribute('data-focus-trap-id');
   });
 
   it('should focus on the element that has the data-autofocus attribute', async () => {
@@ -193,5 +194,24 @@ describe('focus_trap', () => {
 
     await sendKeys({ press: 'Shift+Tab' });
     expect(document.activeElement).to.equal(el.querySelector('#dynamic-button'));
+  });
+
+  it('should be able to release the focus trap', async () => {
+    const el: HTMLElement = await fixture(html`
+      <div>
+        <button type="button">Button</button>
+        <div id="container">
+          <button type="button">Button 1</button>
+        </div>
+      </div>
+    `);
+
+    const container = el.querySelector<HTMLElement>('#container')!;
+    const trap = focusTrap(container);
+
+    expect(container).to.have.attribute('data-focus-trap-id');
+
+    trap.abort();
+    expect(container).not.to.have.attribute('data-focus-trap-id');
   });
 });

--- a/src/helpers/focus_trap.ts
+++ b/src/helpers/focus_trap.ts
@@ -62,6 +62,7 @@ export default function focusTrap(
   signal.addEventListener('abort', () => {
     const sentinels = container.parentNode?.querySelectorAll(`[data-sentinel-for="${id}"]`);
     sentinels?.forEach((sentinel) => sentinel.remove());
+    container.removeAttribute('data-focus-trap-id');
 
     containerStack.delete(container);
     recentlyFocused = null;


### PR DESCRIPTION
This PR removes the `data-focus-trap-id` attribute from the container after the focus trap is released from it.