### PR TITLE
[Closes #31] Add support for option groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support grouping options in `SelectComponent` and `AjaxSelectComponent`
+
 ### Fixed
 
 - Only hide the last opened popover when clicking outside if there are multiple nested popovers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.15.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -215,7 +215,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket (1.2.9)
+    websocket (1.2.10)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.34)
@@ -237,7 +237,7 @@ DEPENDENCIES
   railties (>= 6.1)
   rake (~> 13.0)
   rspec (~> 3.0)
-  selenium-webdriver (~> 4.10)
+  selenium-webdriver (~> 4.15)
   solargraph-standardrb
   sprockets
   sprockets-rails

--- a/app/components/impulse/autocomplete/group_component.html.erb
+++ b/app/components/impulse/autocomplete/group_component.html.erb
@@ -1,0 +1,6 @@
+<%= render(Impulse::BaseRenderer.new(**@system_args)) do %>
+  <%= tag.div @title, id: @id, class: "awc-autocomplete-group-header" %>
+  <% options.each do |option| %>
+    <%= option %>
+  <% end %>
+<% end %>

--- a/app/components/impulse/autocomplete/group_component.rb
+++ b/app/components/impulse/autocomplete/group_component.rb
@@ -1,0 +1,26 @@
+module Impulse
+  module Autocomplete
+    class GroupComponent < ApplicationComponent
+      renders_many :options, Impulse::Autocomplete::OptionComponent
+
+      def initialize(title:, **system_args)
+        @id = self.class.generate_id
+        @title = title
+        @system_args = system_args
+        @system_args[:tag] = :div
+        @system_args[:role] = :group
+        @system_args["aria-labelledby"] = @id
+        @system_args[:class] = class_names(system_args[:class], "awc-autocomplete-group")
+
+        @system_args[:data] = merge_attributes(
+          system_args[:data],
+          target: "awc-autocomplete.groups"
+        )
+      end
+
+      def render?
+        options.present?
+      end
+    end
+  end
+end

--- a/app/components/impulse/autocomplete_component.rb
+++ b/app/components/impulse/autocomplete_component.rb
@@ -2,7 +2,10 @@ module Impulse
   class AutocompleteComponent < ApplicationComponent
     renders_one :blankslate
     renders_one :error
-    renders_many :options, Impulse::Autocomplete::OptionComponent
+    renders_many :options, types: {
+      option: {renders: Impulse::Autocomplete::OptionComponent, as: :option},
+      group: {renders: Impulse::Autocomplete::GroupComponent, as: :group}
+    }
 
     DEFAULT_SIZE = :md
     SIZE_MAPPINGS = {

--- a/app/components/impulse/select_component.html.erb
+++ b/app/components/impulse/select_component.html.erb
@@ -5,7 +5,15 @@
     <% end %>
   <% else %>
     <% options_from_choices.each do |option| %>
-      <%= c.with_option(value: option.value, text: option.text, **option.html_attributes) %>
+      <% if option.is_a?(Array) %>
+        <% c.with_group(title: option.first) do |group| %>
+          <% option.second.each do |grouped_option| %>
+            <% group.with_option(value: grouped_option.value, text: grouped_option.text, **grouped_option.html_attributes) %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= c.with_option(value: option.value, text: option.text, **option.html_attributes) %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/components/impulse/select_component.rb
+++ b/app/components/impulse/select_component.rb
@@ -23,15 +23,31 @@ module Impulse
 
     def options_from_choices
       return [] if @choices.nil?
-      @choices.map do |choice|
+      return grouped_options_for_select(@choices) if grouped_choices?
+      options_for_select(@choices)
+    end
+
+    def options_for_select(choices)
+      choices.map do |choice|
         html_attributes = option_html_attributes(choice)
         text, value = option_text_and_value(choice)
         OptionStruct.new(value, text, html_attributes)
       end
     end
 
+    def grouped_options_for_select(grouped_choices)
+      grouped_choices.map do |grouped_choice|
+        title, container = grouped_choice
+        [title, options_for_select(container)]
+      end
+    end
+
     def find_option(value)
-      (options.presence || options_from_choices).find { |option| option.value.to_s == value.to_s }
+      (options.presence || options_from_choices).flatten.find { |option| option.try(:value)&.to_s == value.to_s }
+    end
+
+    def grouped_choices?
+      @choices.present? && @choices.first.respond_to?(:last) && Array === @choices.first.last
     end
 
     def multiple?

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -86,6 +86,33 @@ Do not add "aria-selected" attribute to an option. If you want to select an opti
 [`selected`](#selecting-an-option) argument.
 :::
 
+### Grouping options
+
+Similarly to rails' [`grouped_collection_select`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-grouped_collection_select)
+method, the select component also supports grouping options. You can pass an array or a hash of grouped options.
+
+```erb
+<%
+  grouped_options = [
+    ["North America", [["United States", "US"], ["Canada", "CN", {disabled: true}]]],
+    ["Europe", ["Denmark", "Germany"]]
+  ]
+%>
+
+<%= render(Impulse::SelectComponent.new(:user, :country_id, grouped_options, selected: "US")) %>
+```
+
+```erb
+<%
+  grouped_options = {
+    "North America" => [["United States", "US"], "Canada"],
+    "Europe" => ["Denmark", "Germany"]
+  }
+%>
+
+<%= render(Impulse::SelectComponent.new(:user, :country_id, grouped_options, selected: "US")) %>
+```
+
 ### Custom blankslate
 
 A blankslate is displayed when the input's text does not match any of the options.

--- a/impulse_view_components.gemspec
+++ b/impulse_view_components.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "capybara", "~> 3.39", ">= 3.39.2"
   spec.add_development_dependency "byebug", "~> 11.1", ">= 11.1.3"
-  spec.add_development_dependency "selenium-webdriver", "~> 4.10"
+  spec.add_development_dependency "selenium-webdriver", "~> 4.15"
   spec.add_development_dependency "webmock", "~> 3.18", ">= 3.18.1"
 end

--- a/previews/impulse/autocomplete_component_preview.rb
+++ b/previews/impulse/autocomplete_component_preview.rb
@@ -35,6 +35,36 @@ module Impulse
 
     # @display center true
     # @display max_width true
+    def grouped_options_single_select
+      render(Impulse::AutocompleteComponent.new(:user, :country_id, selected: OpenStruct.new(value: "CN", text: "Canada"))) do |c|
+        c.with_group(title: "North America") do |g|
+          g.with_option(value: "US", text: "United States")
+          g.with_option(value: "CN", text: "Canada")
+        end
+        c.with_group(title: "Europe") do |g|
+          g.with_option(value: "DK", text: "Denmark")
+          g.with_option(value: "DE", text: "Germany")
+        end
+      end
+    end
+
+    # @display center true
+    # @display max_width true
+    def grouped_options_multiple_select
+      render(Impulse::AutocompleteComponent.new(:user, :country_ids, multiple: true)) do |c|
+        c.with_group(title: "North America") do |g|
+          g.with_option(value: "US", text: "United States")
+          g.with_option(value: "CN", text: "Canada")
+        end
+        c.with_group(title: "Europe") do |g|
+          g.with_option(value: "DK", text: "Denmark")
+          g.with_option(value: "DE", text: "Germany")
+        end
+      end
+    end
+
+    # @display center true
+    # @display max_width true
     def multiple_ajax_select
       render(Impulse::AutocompleteComponent.new(:user, :fruit_ids, src: "/users", selected: [OpenStruct.new(value: "arnold_winnie", text: "Arnold Winnie")], multiple: true))
     end

--- a/previews/impulse/select_component_preview.rb
+++ b/previews/impulse/select_component_preview.rb
@@ -87,6 +87,26 @@ module Impulse
 
     # @display center true
     # @display max_width true
+    def grouped_options_single_select
+      grouped_options = [
+        ["North America", [["United States", "US"], ["Canada", "CN", {disabled: true}]]],
+        ["Europe", ["Denmark", "Germany"]]
+      ]
+      render(Impulse::SelectComponent.new(:user, :fruit_id, grouped_options, selected: "US"))
+    end
+
+    # @display center true
+    # @display max_width true
+    def grouped_options_multiple_select
+      grouped_options = [
+        ["North America", [["United States", "US"], ["Canada", "CN", {disabled: true}]]],
+        ["Europe", ["Denmark", "Germany"]]
+      ]
+      render(Impulse::SelectComponent.new(:user, :fruit_id, grouped_options, selected: ["US"], multiple: true))
+    end
+
+    # @display center true
+    # @display max_width true
     def custom_blankslate
       render(Impulse::SelectComponent.new(:user, :fruit_id)) do |c|
         c.with_blankslate { "Nothing found" }

--- a/src/elements/autocomplete/index.scss
+++ b/src/elements/autocomplete/index.scss
@@ -104,12 +104,16 @@
 .awc-autocomplete-options {
   margin: 0;
   padding: 0;
+
+  .awc-autocomplete-group:not([hidden]) ~ :not([hidden]) {
+    border-top: 1px solid var(--color-border-default);
+    margin-top: var(--space-1);
+  }
 }
 
-// Group header
+// Group
 .awc-autocomplete-group-header {
   padding: var(--awc-autocomplete-group-header-padding-y) var(--awc-autocomplete-group-header-padding-x);
-  background-color: var(--awc-autocomplete-group-header-bg-color);
   line-height: var(--awc-autocomplete-group-header-lh);
   font-size: var(--awc-autocomplete-group-header-font-size);
   font-weight: var(--awc-autocomplete-group-header-fw);

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -52,6 +52,7 @@ export default class AwcAutocompleteElement extends ImpulseElement {
   @target() optionsContainer: HTMLElement;
   @target() clearBtn?: HTMLButtonElement;
   @targets() tagDismissBtns?: HTMLButtonElement[];
+  @targets() groups: HTMLElement[];
 
   combobox: Combobox;
   private singleSelect = new SingleSelect(this);
@@ -141,6 +142,9 @@ export default class AwcAutocompleteElement extends ImpulseElement {
       if (!this.src) {
         for (const option of this.options) {
           option.hidden = false;
+        }
+        for (const group of this.groups) {
+          group.hidden = false;
         }
       }
       this.removeAttribute('no-options');
@@ -501,12 +505,21 @@ export default class AwcAutocompleteElement extends ImpulseElement {
 
 function filterOptions(query: string) {
   return (target: HTMLElement) => {
+    const group = target.closest<HTMLElement>('[role="group"]');
+
     if (query) {
       const value = getText(target);
       const match = value?.toLowerCase().includes(query.toLowerCase());
       target.hidden = !match;
+      if (group) {
+        const options = Array.from(group.querySelectorAll<HTMLElement>('[role="option"]'));
+        group.hidden = options.every((o) => o.hidden);
+      }
     } else {
       target.hidden = false;
+      if (group) {
+        group.hidden = false;
+      }
     }
   };
 }

--- a/src/elements/autocomplete/multiple_select.ts
+++ b/src/elements/autocomplete/multiple_select.ts
@@ -57,6 +57,9 @@ export default class MultipleSelect {
       for (const option of this.autocomplete.options) {
         option.hidden = false;
       }
+      for (const group of this.autocomplete.groups) {
+        group.hidden = false;
+      }
     }
   }
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -60,7 +60,6 @@
   --awc-autocomplete-group-header-padding-x: var(--awc-autocomplete-option-padding-x);
   --awc-autocomplete-group-header-padding-y: 0.25rem;
   --awc-autocomplete-group-header-color: #384b6e; // n600
-  --awc-autocomplete-group-header-bg-color: #eef4ff; // n20
   --awc-autocomplete-group-header-font-size: 0.75rem;
   --awc-autocomplete-group-header-lh: 18px;
   --awc-autocomplete-group-header-fw: 400;

--- a/test/components/autocomplete/group_component_test.rb
+++ b/test/components/autocomplete/group_component_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+module Autocomplete
+  class GroupComponentTest < ApplicationTest
+    test "renders a group of options" do
+      render_inline(Impulse::Autocomplete::GroupComponent.new(title: "My group")) do |c|
+        c.with_option(value: "apple", text: "Apple")
+      end
+
+      assert_selector ".awc-autocomplete-group[data-target='awc-autocomplete.groups']"
+      assert_selector ".awc-autocomplete-group[role='group']" do
+        assert_selector "[role='option']", text: "Apple"
+      end
+    end
+
+    test "links group with title" do
+      render_inline(Impulse::Autocomplete::GroupComponent.new(title: "My group")) do |c|
+        c.with_option(value: "apple", text: "Apple")
+      end
+
+      id = page.find("[role='group']")["aria-labelledby"]
+      assert_selector "##{id}", text: "My group"
+    end
+
+    test "title has a class" do
+      render_inline(Impulse::Autocomplete::GroupComponent.new(title: "My group")) do |c|
+        c.with_option(value: "apple", text: "Apple")
+      end
+
+      assert_selector ".awc-autocomplete-group-header", text: "My group"
+    end
+
+    test "custom class can be added to the group container" do
+      render_inline(Impulse::Autocomplete::GroupComponent.new(title: "My group", class: "custom-class")) do |c|
+        c.with_option(value: "apple", text: "Apple")
+      end
+
+      assert_selector ".awc-autocomplete-group.custom-class"
+    end
+
+    test "does not render the component if options are missing" do
+      render_inline(Impulse::Autocomplete::GroupComponent.new(title: "My group", class: "custom-class"))
+
+      refute_component_rendered
+    end
+  end
+end

--- a/test/components/autocomplete_component_test.rb
+++ b/test/components/autocomplete_component_test.rb
@@ -105,5 +105,18 @@ module Impulse
 
       assert_selector "[data-behavior='hidden-field'][name='custom_name']", visible: false
     end
+
+    test "grouped options" do
+      render_inline(Impulse::AutocompleteComponent.new(:user, :fruit_id)) do |c|
+        c.with_group(title: "My group") do |g|
+          g.with_option(value: "first", text: "First")
+        end
+      end
+
+      assert_selector "[role='group']", visible: false do
+        assert_selector "div", text: "My group", visible: false
+        assert_selector "[value='first']", text: "First", visible: false
+      end
+    end
   end
 end

--- a/test/components/select_component_test.rb
+++ b/test/components/select_component_test.rb
@@ -70,5 +70,34 @@ module Impulse
         render_inline(Impulse::SelectComponent.new(:user, :fruit_id, ["Apple", "Guava"], selected: ["Invalid", "Apple"], multiple: true))
       end
     end
+
+    test "grouped options" do
+      grouped_options = [["North America", [["United States", "US"], "Canada"]]]
+      render_inline(Impulse::SelectComponent.new(:user, :fruit_id, grouped_options))
+
+      assert_selector "[role='group']", visible: false do
+        assert_selector "div", text: "North America", visible: false
+        assert_selector "[value='US']", text: "United States", visible: false
+        assert_selector "[value='Canada']", text: "Canada", visible: false
+      end
+    end
+
+    test "selects an option from grouped options" do
+      grouped_options = [
+        ["North America", [["United States", "US"], "Canada"]],
+        ["Europe", ["Denmark", "Germany"]]
+      ]
+      render_inline(Impulse::SelectComponent.new(:user, :fruit_id, grouped_options, selected: "Canada"))
+
+      assert_selector "awc-autocomplete[value='Canada']"
+      assert_selector "[data-behavior='hidden-field'][value='Canada']", visible: false
+    end
+
+    test "HTML attributes can be passed to one of the option within the group" do
+      grouped_options = [["North America", [["United States", "US", {disabled: true}], "Canada"]]]
+      render_inline(Impulse::SelectComponent.new(:user, :fruit_id, grouped_options))
+
+      assert_selector "[role='option'][value='US'][disabled]", visible: false
+    end
   end
 end

--- a/test/system/autocomplete_test.rb
+++ b/test/system/autocomplete_test.rb
@@ -121,5 +121,50 @@ module Impulse
       refute_selector "[role='option']"
       assert_selector "awc-autocomplete[no-options]"
     end
+
+    test "filters options within a group" do
+      visit_preview(:grouped_options_single_select)
+      page.find(".awc-autocomplete-control").click
+
+      assert_selector "[role='group']", count: 2
+      assert_selector "[role='option']", count: 4
+
+      fill_in "user_country_id", with: "den"
+      assert_selector "[role='group']", count: 1
+      assert_selector "[role='option']", count: 1
+    end
+
+    test "resets the group after filtering and closing the listbox" do
+      visit_preview(:grouped_options_single_select)
+      page.find(".awc-autocomplete-control").click
+
+      fill_in "user_country_id", with: "den"
+      assert_selector "[role='group']", count: 1
+      assert_selector "[role='option']", count: 1
+
+      page.find("[role='option'][value='DK']").click
+      refute_selector "[role='listbox']" # Closes the listbox
+
+      page.find(".awc-autocomplete-control").click
+      assert_selector "[role='group']", count: 2
+      assert_selector "[role='option']", count: 4
+    end
+
+    test "resets the group after selecting an option" do
+      visit_preview(:grouped_options_multiple_select)
+      page.find(".awc-autocomplete-control").click
+
+      assert_selector "[role='group']", count: 2
+      assert_selector "[role='option']", count: 4
+
+      fill_in "user_country_ids", with: "den"
+      assert_selector "[role='group']", count: 1
+      assert_selector "[role='option']", count: 1
+
+      page.find("[role='option'][value='DK']").click
+      assert_selector "[role='listbox']" # Does not close the listbox
+      assert_selector "[role='group']", count: 2
+      assert_selector "[role='option']", count: 4
+    end
   end
 end


### PR DESCRIPTION
This PR adds a way to group options in the `SelectComponent` and `AjaxSelectComponent` similar to the rails' `grouped_options_for_select` method.

```erb
<%
  grouped_options = [
    ["North America", [["United States", "US"], ["Canada", "CN", {disabled: true}]]],
    ["Europe", ["Denmark", "Germany"]]
  ]
%>

<%= render(Impulse::SelectComponent.new(:user, :country_id, grouped_options, selected: "US")) %>
```