### PR TITLE
Add `TimeZoneSelect` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `TimeZoneSelectComponent`
 - Support grouping options in `SelectComponent` and `AjaxSelectComponent`
 
 ### Fixed

--- a/app/components/impulse/time_zone_select_component.html.erb
+++ b/app/components/impulse/time_zone_select_component.html.erb
@@ -1,0 +1,20 @@
+<%= render(Impulse::AutocompleteComponent.new(@object_name, @method_name, selected: value, **@system_args)) do |c| %>
+  <% if prioritized? %>
+    <% c.with_group(title: @priority_zones_title) do |group| %>
+      <% options[:priority_zones].each do |option| %>
+        <% group.with_option(value: option.name, text: option.to_s, data: {test_id: "priority-zones"}) %>
+      <% end %>
+    <% end %>
+    <% c.with_group(title: "Other") do |group| %>
+      <% options[:other].each do |option| %>
+        <% group.with_option(value: option.name, text: option.to_s, data: {test_id: "unprioritized-zones"}) %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <% options[:other].each do |option| %>
+      <% c.with_option(value: option.name, text: option.to_s) %>
+    <% end %>
+  <% end %>
+
+  <% c.with_blankslate_content(blankslate.presence || "We couldn't find that time zone!") %>
+<% end %>

--- a/app/components/impulse/time_zone_select_component.rb
+++ b/app/components/impulse/time_zone_select_component.rb
@@ -1,0 +1,66 @@
+module Impulse
+  class TimeZoneSelectComponent < ApplicationComponent
+    renders_one :blankslate
+
+    OptionStruct = Struct.new(:value, :text)
+
+    def initialize(object_name, method_name, priority_zones = nil, selected: nil, default: nil, model: ::ActiveSupport::TimeZone, priority_zones_title: "Priority zones", **system_args)
+      @object_name = object_name
+      @method_name = method_name
+      @priority_zones = priority_zones
+      @selected = selected
+      @default = default
+      @model = model
+      @priority_zones_title = priority_zones_title
+      @system_args = system_args
+    end
+
+    private
+
+    def options
+      priority_zones = @priority_zones
+
+      zones = Hash.new { |h, k| h[k] = [] }.tap do |hash|
+        model = @model.all
+
+        if priority_zones
+          if priority_zones.is_a?(Regexp)
+            priority_zones = model.select { |z| z.match?(priority_zones) }
+          end
+
+          hash[:priority_zones] = priority_zones
+          model -= priority_zones
+        end
+
+        hash[:other] = model
+      end
+
+      if zones[:other].blank?
+        zones[:other] = zones[:priority_zones]
+        zones[:priority_zones] = []
+      end
+
+      zones
+    end
+
+    def value
+      find_option(selected) if selected.present?
+    end
+
+    def options_from_choices
+      @model.all.map { |option| OptionStruct.new(option.name, option.to_s) }
+    end
+
+    def find_option(value)
+      options_from_choices.find { |option| option.value == value }
+    end
+
+    def selected
+      @selected || @default
+    end
+
+    def prioritized?
+      options[:priority_zones].present?
+    end
+  end
+end

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -41,6 +41,10 @@ export default defineConfig({
             text: 'Spinner',
             link: '/components/spinner',
           },
+          {
+            text: 'Time zone select',
+            link: '/components/time-zone-select',
+          },
         ],
       },
       {

--- a/docs/components/time-zone-select.md
+++ b/docs/components/time-zone-select.md
@@ -1,0 +1,114 @@
+# Time zone select
+
+Time zone select allows a user to filter through a list of default time zones and select one or multiple values.
+
+## Usage
+
+```erb
+<%= render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone)) %>
+```
+
+## Arguments
+
+### Positional arguments
+
+| Name           | Default   | Description                                                                  |
+| ------         | --------- | -------------                                                                |
+| object_name    | N/A       | The name of the object.                                                      |
+| method_name    | N/A       | The name of the method.                                                      |
+| priority_zones | `nil`     | A list of time zones that will be listed above the rest of the (long) list. |
+
+### Keyword arguments
+
+| Name                 | Default                   | Description                                                                                                                                                                                                                                      |
+| ------               | ---------                 | -------------                                                                                                                                                                                                                                    |
+| selected             | `nil`                     | The `value` of the option that you want to force select.                                                                                                                                                                                         |
+| default              | `nil`                     | The `value` of the option that you want to select if the `selected` is `nil`.                                                                                                                                                                    |
+| model                | `ActiveSupport::TimeZone` | A list of time zones that should respond to `all` and return an array of objects that represent time zones; each object must respond to `name` and `to_s`. If a `Regexp` is given, it will attempt to match the zones using the `match?` method. |
+| priority_zones_title | "Priority zones"          | The title of the group of time zones that have been prioritized.                                                                                                                                                                                 |
+| size                 | `md`                      | The size of the select control. One of `sm`, `md`, or `lg`.                                                                                                                                                                                      |
+| name                 | `nil`                     | The name of the field. By default rails will automatically create a `name` string based on the `object_name` and `method_name`.                                                                                                                  |
+| input_id             | `nil`                     | The id of the input field.                                                                                                                                                                                                                       |
+| placeholder          | `nil`                     | The placeholder text that is displayed within the input field.                                                                                                                                                                                   |
+| include_hidden       | `true`                    | See the "Gotcha" section of rails [`select`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select) tag.                                                                                                 |
+| disabled             | `false`                   | Disables the select control.                                                                                                                                                                                                                     |
+| required             | `false`                   | Makes the select control a required field.                                                                                                                                                                                                       |
+| multiple             | `false`                   | Whether multiple values can be selected or not.                                                                                                                                                                                                  |
+| clearable            | `true`                    | Whether the clear button should be shown or not.                                                                                                                                                                                                 |
+
+## Examples
+
+### Prioritizing zones
+
+You can also supply an array of [`ActiveSupport::TimeZone`](https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html),
+[`ActiveSupport::TimeZone.us_zones`](https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html#method-c-us_zones)
+for a list of US time zones, [`ActiveSupport::TimeZone.country_zones(country_code)`](https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html#method-c-country_zones)
+for another country’s time zones or a [`Regexp`](https://api.rubyonrails.org/classes/Regexp.html) to select the zones
+of your choice.
+
+```erb
+<%= render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, ActiveSupport::TimeZone.us_zones)) %>
+<%= render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, [ActiveSupport::TimeZone["Alaska"], ActiveSupport::TimeZone["Hawaii"]])) %>
+<%= render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, /Australia/)) %>
+<%= render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, ActiveSupport::TimeZone.all.sort)) %>
+```
+
+### Custom blankslate
+
+A blankslate is displayed when the input's text does not match any of the options.
+
+```erb{2}
+<%= render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone)) do |c| %>
+  <% c.with_blankslate { "We could not find that time zone in our directory!" } %>
+<% end %>
+```
+
+### Integrating with `form_with`
+
+Wrap your `time_zone_select` tag with the `impulse_form_with` method. The `f.time_zone_select` tag accepts the same [arguments](#arguments).
+
+```erb
+<%= impulse_form_with model: @user do |f| %>
+  <%= f.select :time_zone %>
+<% end %>
+
+<%= impulse_form_with model: @user do |f| %>
+  <%= f.select :time_zone, ActiveSupport::TimeZone.us_zones %>
+<% end %>
+
+<%= impulse_form_with model: @user do |f| %>
+  <%= f.select :time_zone, nil, default: "Hawaii" %>
+<% end %>
+
+<%= impulse_form_with model: @user do |f| %>
+  <%= f.select :time_zone do |c| %>
+    <% c.with_blankslate { "Time zone not found!" } %>
+  <% end %>
+<% end %>
+```
+
+## Slots
+
+### `with_blankslate`
+
+Overwrite the default blankslate message by passing a custom block.
+
+| Name          | Default   | Description                                                               |
+| ------        | --------- | -------------                                                             |
+| `system_args` | `{}`      | HTML attributes that should be passed to the Rails' `content_tag` method. |
+
+## Imports
+
+::: code-group
+```js
+import '@ambiki/impulse-view-components/dist/elements/autocomplete';
+```
+
+```scss
+@import '~@ambiki/impulse-view-components/dist/elements/autocomplete';
+```
+:::
+
+## JS API
+
+[Read here](../js-api/autocomplete.md).

--- a/lib/impulse/forms/builder.rb
+++ b/lib/impulse/forms/builder.rb
@@ -26,6 +26,17 @@ module Impulse
           **system_args
         ).render_tag(&block)
       end
+
+      def time_zone_select(method_name, priority_zones = nil, **system_args, &block)
+        Tags::TimeZoneSelect.new(
+          object:,
+          object_name:,
+          method_name:,
+          template:,
+          priority_zones:,
+          **system_args
+        ).render_tag(&block)
+      end
     end
   end
 end

--- a/lib/impulse/forms/tags/time_zone_select.rb
+++ b/lib/impulse/forms/tags/time_zone_select.rb
@@ -1,0 +1,27 @@
+module Impulse
+  module Forms
+    module Tags
+      class TimeZoneSelect < Base
+        def initialize(object:, object_name:, method_name:, template:, priority_zones:, **system_args)
+          super(object:, object_name:, method_name:, template:, **system_args)
+          @priority_zones = priority_zones
+          @value = @system_args.fetch(:selected, value)
+        end
+
+        def render_tag(&block)
+          if block
+            render(component) { |c| yield c }
+          else
+            render(component)
+          end
+        end
+
+        private
+
+        def component
+          Impulse::TimeZoneSelectComponent.new(@object_name, @method_name, @priority_zones, selected: @value, **@system_args)
+        end
+      end
+    end
+  end
+end

--- a/previews/impulse/time_zone_select_component_preview.rb
+++ b/previews/impulse/time_zone_select_component_preview.rb
@@ -1,0 +1,48 @@
+module Impulse
+  class TimeZoneSelectComponentPreview < ViewComponent::Preview
+    # @display center true
+    # @display max_width true
+    # @param size select ["sm", "md", "lg"]
+    # @param placeholder text
+    # @param disabled toggle
+    # @param clearable toggle
+    def single_select(size: :md, placeholder: "Select a time zone", disabled: false, clearable: true)
+      render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, nil, size:, placeholder:, disabled:, clearable:))
+    end
+
+    # @display center true
+    # @display max_width true
+    # @param size select ["sm", "md", "lg"]
+    # @param placeholder text
+    # @param disabled toggle
+    # @param clearable toggle
+    def multiple_select(size: :md, placeholder: "Select time zones", disabled: false, clearable: true)
+      render(Impulse::TimeZoneSelectComponent.new(:user, :time_zones, nil, multiple: true, size:, placeholder:, disabled:, clearable:))
+    end
+
+    # @!group Priority zones
+    # @display center true
+    # @display max_width true
+    # @param priority_zones_title text
+    def us_zones(priority_zones_title: "Priority zones")
+      render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, ActiveSupport::TimeZone.us_zones, priority_zones_title:))
+    end
+
+    # @param priority_zones_title text
+    def regex(priority_zones_title: "Priority zones")
+      render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, /Australia/, priority_zones_title:))
+    end
+
+    def sorted
+      render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, ActiveSupport::TimeZone.all.sort))
+    end
+
+    # @!endgroup
+
+    # @display center true
+    # @display max_width true
+    def form_with_single_select
+      render_with_template
+    end
+  end
+end

--- a/previews/impulse/time_zone_select_component_preview/form_with_single_select.html.erb
+++ b/previews/impulse/time_zone_select_component_preview/form_with_single_select.html.erb
@@ -1,0 +1,4 @@
+<%= impulse_form_with model: nil, url: "/users" do |f| %>
+  <%= f.label :time_zone %>
+  <%= f.time_zone_select :time_zone %>
+<% end %>

--- a/test/components/time_zone_select_component_test.rb
+++ b/test/components/time_zone_select_component_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+module Impulse
+  class TimeZoneSelectComponentTest < ApplicationTest
+    test "renders the component" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone))
+
+      assert_selector "awc-autocomplete"
+      assert_selector "[role='option']", count: ::ActiveSupport::TimeZone.all.size, visible: false
+    end
+
+    test "selects an option" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, nil, selected: "Hawaii"))
+
+      assert_selector "[data-behavior='hidden-field'][value='Hawaii']", visible: false
+    end
+
+    test "selects an option using the default option" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, nil, selected: nil, default: "Hawaii"))
+
+      assert_selector "[data-behavior='hidden-field'][value='Hawaii']", visible: false
+    end
+
+    test "selected option is preferred over the default option" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, nil, selected: "Alaska", default: "Hawaii"))
+
+      assert_selector "[data-behavior='hidden-field'][value='Alaska']", visible: false
+    end
+
+    test "does not raise an error if option cannot be found" do
+      assert_nothing_raised do
+        render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, nil, selected: "Invalid"))
+      end
+    end
+
+    test "prioritizes time zones" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, ActiveSupport::TimeZone.us_zones))
+
+      assert_selector "[role='group']", text: "Priority zones", visible: false
+      assert_selector "[role='group']", text: "Other", visible: false
+      assert_selector "[data-test-id='priority-zones']", count: ActiveSupport::TimeZone.us_zones.size, visible: false
+      assert_selector "[data-test-id='unprioritized-zones']", count: (ActiveSupport::TimeZone.all - ActiveSupport::TimeZone.us_zones).size, visible: false
+    end
+
+    test "prioritizes time zones based on Regexp" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, /Australia/))
+
+      assert_selector "[data-test-id='priority-zones']", count: ActiveSupport::TimeZone.all.count { |z| z.match?(/Australia/) }, visible: false
+    end
+
+    test "does not group time zones if priority_zones does not filter the time zones" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, ActiveSupport::TimeZone.all.sort))
+
+      refute_selector "[role='group']", visible: false
+      assert_selector "[role='option']", count: ActiveSupport::TimeZone.all.size, visible: false
+    end
+
+    test "priority zones title can be changed" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, ActiveSupport::TimeZone.us_zones, priority_zones_title: "US Zones"))
+
+      assert_selector "[role='group']", text: "US Zones", visible: false
+    end
+
+    test "renders a blankslate" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone))
+
+      assert_selector ".awc-autocomplete-blankslate", text: "We couldn't find that time zone!", visible: false
+    end
+
+    test "renders a custom blankslate" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone)) do |c|
+        c.with_blankslate { "Not found" }
+      end
+
+      assert_selector ".awc-autocomplete-blankslate", text: "Not found", visible: false
+    end
+
+    test "renders the time zones from a given list" do
+      time_zones = Class.new do
+        def self.all
+          [OpenStruct.new(name: "My time zone", to_s: "[12:00] My time zone")]
+        end
+      end
+
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, nil, model: time_zones))
+
+      assert_selector "[role='option']", count: 1, visible: false
+      assert_selector "[role='option'][value='My time zone']", text: "[12:00] My time zone", visible: false
+    end
+
+    test "adds a custom class" do
+      render_inline(Impulse::TimeZoneSelectComponent.new(:user, :time_zone, nil, class: "custom-class"))
+
+      assert_selector "awc-autocomplete.custom-class"
+    end
+  end
+end

--- a/test/forms/time_zone_select_test.rb
+++ b/test/forms/time_zone_select_test.rb
@@ -1,0 +1,139 @@
+require "test_helper"
+
+module Impulse
+  class TimeZoneSelectTest < ApplicationTest
+    test "renders the component" do
+      render_in_view_context do
+        impulse_form_with(model: User.new, url: "/users") do |f|
+          f.time_zone_select :time_zone
+        end
+      end
+
+      assert_selector "awc-autocomplete"
+      assert_selector "[role='option']", count: ActiveSupport::TimeZone.all.size, visible: false
+    end
+
+    test "selected option" do
+      model = Class.new do
+        include ActiveModel::Model
+
+        def self.model_name
+          ActiveModel::Name.new(self.class, nil, "User")
+        end
+
+        def time_zone
+          "Hawaii"
+        end
+      end
+
+      render_in_view_context do
+        impulse_form_with(model: model.new, url: "/users") do |f|
+          f.time_zone_select :time_zone
+        end
+      end
+
+      assert_selector "[data-behavior='hidden-field'][value='Hawaii']", visible: false
+    end
+
+    test "default selected option" do
+      model = Class.new do
+        include ActiveModel::Model
+
+        def self.model_name
+          ActiveModel::Name.new(self.class, nil, "User")
+        end
+
+        def time_zone
+          nil
+        end
+      end
+
+      render_in_view_context do
+        impulse_form_with(model: model.new, url: "/users") do |f|
+          f.time_zone_select :time_zone, nil, default: "Hawaii"
+        end
+      end
+
+      assert_selector "[data-behavior='hidden-field'][value='Hawaii']", visible: false
+    end
+
+    test "selected option is preferred over the default option" do
+      model = Class.new do
+        include ActiveModel::Model
+
+        def self.model_name
+          ActiveModel::Name.new(self.class, nil, "User")
+        end
+
+        def time_zone
+          "Alaska"
+        end
+      end
+
+      render_in_view_context do
+        impulse_form_with(model: model.new, url: "/users") do |f|
+          f.time_zone_select :time_zone, nil, default: "Hawaii"
+        end
+      end
+
+      assert_selector "[data-behavior='hidden-field'][value='Alaska']", visible: false
+    end
+
+    test "selected option is preferred over the model attribute" do
+      model = Class.new do
+        include ActiveModel::Model
+
+        def self.model_name
+          ActiveModel::Name.new(self.class, nil, "User")
+        end
+
+        def time_zone
+          "Alaska"
+        end
+      end
+
+      render_in_view_context do
+        impulse_form_with(model: model.new, url: "/users") do |f|
+          f.time_zone_select :time_zone, nil, selected: "Hawaii"
+        end
+      end
+
+      assert_selector "[data-behavior='hidden-field'][value='Hawaii']", visible: false
+    end
+
+    test "prioritizes time zones" do
+      render_in_view_context do
+        impulse_form_with(model: User.new, url: "/users") do |f|
+          f.time_zone_select :time_zone, ActiveSupport::TimeZone.us_zones
+        end
+      end
+
+      assert_selector "[role='group']", text: "Priority zones", visible: false
+      assert_selector "[role='group']", text: "Other", visible: false
+      assert_selector "[data-test-id='priority-zones']", count: ActiveSupport::TimeZone.us_zones.size, visible: false
+      assert_selector "[data-test-id='unprioritized-zones']", count: (ActiveSupport::TimeZone.all - ActiveSupport::TimeZone.us_zones).size, visible: false
+    end
+
+    test "renders multiple select" do
+      render_in_view_context do
+        impulse_form_with(model: User.new, url: "/users") do |f|
+          f.time_zone_select :time_zone, nil, multiple: true
+        end
+      end
+
+      assert_selector "awc-autocomplete[multiple]"
+    end
+
+    test "renders a blankslate" do
+      render_in_view_context do
+        impulse_form_with(model: User.new, url: "/users") do |f|
+          f.time_zone_select :time_zone, ActiveSupport::TimeZone.us_zones do |c|
+            c.with_blankslate { "Not found" }
+          end
+        end
+      end
+
+      assert_selector ".awc-autocomplete-blankslate", text: "Not found", visible: false
+    end
+  end
+end


### PR DESCRIPTION
Closes #32

Usage:
```erb
<%= render(Impulse::TimeZoneSelectComponent.new(:user, :time_zone)) %>
```

Usage with `form_with`:
```erb
<%= impulse_form_with model: User.new do |f| %>
  <%= f.time_zone_select :time_zone %>
<% end %>
```