### PR TITLE
change: replace autocomplete svg icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
@@ -15,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replace autocomplete's svg icons with bootstrap icons
 - Add `box-shadow`, increase group header `font-weight`, and set cursor to `not-allowed` if option is disabled in autocomplete
 
 ### Fixed

--- a/app/components/impulse/autocomplete/option_component.html.erb
+++ b/app/components/impulse/autocomplete/option_component.html.erb
@@ -6,7 +6,5 @@
     <% end %>
   </div>
 
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor" class="awc-autocomplete-option-check" aria-hidden="true">
-    <path fill="none" d="M0 0h24v24H0z"></path><path d="M10.0007 15.1709L19.1931 5.97852L20.6073 7.39273L10.0007 17.9993L3.63672 11.6354L5.05093 10.2212L10.0007 15.1709Z"></path>
-  </svg>
+  <i class="bi bi-check2 awc-autocomplete-option-check" aria-hidden="true"></i>
 <% end %>

--- a/app/components/impulse/autocomplete_component.html.erb
+++ b/app/components/impulse/autocomplete_component.html.erb
@@ -7,9 +7,7 @@
           <span class="awc-autocomplete-tag-text" data-behavior="text"><%= selected.text %></span>
           <span class="awc-autocomplete-tag-end-adornment">
             <%= content_tag :button, type: :button, class: "awc-autocomplete-tag-dismiss-btn btn", tabindex: "-1", title: "Remove", disabled: @disabled, data: { action: "click->awc-autocomplete#handleTagRemove", target: "awc-autocomplete.tagDismissBtns" } do %>
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
-                <path fill="none" d="M0 0h24v24H0z"></path><path d="M12.0007 10.5865L16.9504 5.63672L18.3646 7.05093L13.4149 12.0007L18.3646 16.9504L16.9504 18.3646L12.0007 13.4149L7.05093 18.3646L5.63672 16.9504L10.5865 12.0007L5.63672 7.05093L7.05093 5.63672L12.0007 10.5865Z"></path>
-              </svg>
+              <i class="bi bi-x"></i>
             <% end %>
           </span>
           <%= hidden_field @object_name, @method_name, id: nil, value: selected.value, multiple: true, data: { behavior: "hidden-field" }, **hidden_field_args %>
@@ -21,9 +19,7 @@
           <span class="awc-autocomplete-tag-text" data-behavior="text"></span>
           <span class="awc-autocomplete-tag-end-adornment">
             <%= content_tag :button, type: :button, class: "awc-autocomplete-tag-dismiss-btn btn", tabindex: "-1", title: "Remove", data: { action: "click->awc-autocomplete#handleTagRemove", target: "awc-autocomplete.tagDismissBtns" } do %>
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
-                <path fill="none" d="M0 0h24v24H0z"></path><path d="M12.0007 10.5865L16.9504 5.63672L18.3646 7.05093L13.4149 12.0007L18.3646 16.9504L16.9504 18.3646L12.0007 13.4149L7.05093 18.3646L5.63672 16.9504L10.5865 12.0007L5.63672 7.05093L7.05093 5.63672L12.0007 10.5865Z"></path>
-              </svg>
+              <i class="bi bi-x"></i>
             <% end %>
           </span>
           <%= hidden_field @object_name, @method_name, id: nil, value: nil, multiple: true, data: { behavior: "hidden-field" }, **hidden_field_args %>
@@ -50,12 +46,12 @@
     <div class="awc-autocomplete-end-adornment">
       <% if @clearable %>
         <%= content_tag :button, type: :button, class: "awc-autocomplete-adornment-btn awc-autocomplete-clear-btn btn btn-light", title: "Clear", disabled: @disabled, data: { action: "click->awc-autocomplete#handleClear", target: "awc-autocomplete.clearBtn" } do %>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path fill="none" d="M0 0h24v24H0z"></path><path d="M12.0007 10.5865L16.9504 5.63672L18.3646 7.05093L13.4149 12.0007L18.3646 16.9504L16.9504 18.3646L12.0007 13.4149L7.05093 18.3646L5.63672 16.9504L10.5865 12.0007L5.63672 7.05093L7.05093 5.63672L12.0007 10.5865Z"></path></svg>
+          <i class="bi bi-x-lg"></i>
         <% end %>
       <% end %>
 
       <div aria-hidden="true" class="awc-autocomplete-adornment-decorator">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path fill="none" d="M0 0h24v24H0z"></path><path d="M12 16L6 10H18L12 16Z"></path></svg>
+        <i class="bi bi-caret-down-fill"></i>
       </div>
     </div>
   <% end %>

--- a/src/elements/autocomplete/index.scss
+++ b/src/elements/autocomplete/index.scss
@@ -76,7 +76,19 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.125rem;
+  border-radius: var(--rounded-sm);
+  font-size: var(--fs-sm);
+
+  i {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-style: normal;
+
+    &::before {
+      line-height: inherit;
+    }
+  }
 }
 
 // Hide clear btn when there are no selections
@@ -126,6 +138,10 @@
   color: var(--awc-autocomplete-option-check-color);
   flex-shrink: 0;
   visibility: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--fs-xl);
 }
 
 .awc-autocomplete-option {
@@ -230,7 +246,8 @@
   justify-content: center;
   height: var(--awc-autocomplete-tag-btn-size);
   width: var(--awc-autocomplete-tag-btn-size);
-  border-radius: 0.125rem;
+  border-radius: var(--rounded-sm);
+  font-size: var(--fs-lg);
 
   &:hover {
     background-color: var(--awc-autocomplete-tag-btn-bg-hover-color);
@@ -240,6 +257,17 @@
   &[disabled] {
     background-color: transparent;
     color: inherit;
+  }
+
+  i {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-style: normal;
+
+    &::before {
+      line-height: inherit;
+    }
   }
 }
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -16,6 +16,7 @@
   --fs-sm: 0.8125rem;
   --fs-default: 0.875rem;
   --fs-lg: 1rem;
+  --fs-xl: 1.25rem;
 
   /** Font weights */
   --fw-default: 400;


### PR DESCRIPTION
This PR focuses on increasing the consistency of the icons with the Ambiki app by replacing the autocomplete's SVG icons with the bootstrap icons.