### PR TITLE
change(popover): avoid rendering header by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Avoid rendering Popover's header by default
 - Use [`popover`](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) API in `PopoverComponent`
 
 ## [0.3.0] - 2023-12-21

--- a/app/components/impulse/popover_component.rb
+++ b/app/components/impulse/popover_component.rb
@@ -29,7 +29,7 @@ module Impulse
       Impulse::BaseRenderer.new(**system_args)
     }
 
-    def initialize(title:, click_boundaries: [], **system_args)
+    def initialize(title: nil, click_boundaries: [], **system_args)
       @title = title
       @system_args = system_args
       @system_args[:tag] = :"awc-popover"

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -5,8 +5,8 @@ A popover is a floating panel that can display rich content like navigation menu
 ## Usage
 
 ```erb
-<%= render(Impulse::PopoverComponent.new(title: "Activity feed")) do |c| %>
-  <% c.with_trigger { "Toggle popover" } %>
+<%= render(Impulse::PopoverComponent.new) do |c| %>
+  <% c.with_trigger(class: "btn btn-primary") { "Toggle popover" } %>
   <% c.with_body do %>
     <span>And here's some amazing content. It's very engaging. Right?</span>
   <% end %>
@@ -15,29 +15,46 @@ A popover is a floating panel that can display rich content like navigation menu
 
 ## Arguments
 
-| Name             | Default   | Description                                                                                                                                                                                                                                                            |
-| ------           | --------- | -------------                                                                                                                                                                                                                                                          |
-| title            | N/A       | The title of the popover.                                                                                                                                                                                                                                              |
-| placement        | `bottom`  | The preferred placement of the popover. The actual placement may vary to keep the element inside the viewport. One of `top`, `top-start`, `top-end`, `right`, `right-start`, `right-end`, `bottom`, `bottom-start`, `bottom-end`, `left`, `left-start`, or `left-end`. |
-| strategy         | `fixed`   | The value of the `position` CSS property. One of `absolute` or `fixed`.                                                                                                                                                                                                |
-| click_boundaries | `[]`      | The CSS selector of the element that should avoid closing the popover when clicked inside.                                                                                                                                                                             |
+| Name             | Default    | Description                                                                                                                                                                                                                                                            |
+| ------           | ---------  | -------------                                                                                                                                                                                                                                                          |
+| title            | `nil`      | The title of the popover.                                                                                                                                                                                                                                              |
+| placement        | `bottom`   | The preferred placement of the popover. The actual placement may vary to keep the element inside the viewport. One of `top`, `top-start`, `top-end`, `right`, `right-start`, `right-end`, `bottom`, `bottom-start`, `bottom-end`, `left`, `left-start`, or `left-end`. |
+| strategy         | `absolute` | The value of the `position` CSS property. One of `absolute` or `fixed`.                                                                                                                                                                                                |
+| click_boundaries | `[]`       | The CSS selector of the element that should avoid closing the popover when clicked inside.                                                                                                                                                                             |
 
 ## Examples
 
+### Adding a title
+
+You can add a title by setting the `title` argument on the component. It will also add a close button next to it.
+
+```erb{1}
+<%= render(Impulse::PopoverComponent.new(title: "Activity feed")) do |c| %>
+  <% c.with_trigger { "Open feed" } %>
+  <% c.with_body { "Body" } %>
+<% end %>
+```
+
 ### Custom header
 
-You can customize the header to add rich content instead of a simple title by calling the `with_header` slot. You will
-still need to pass the `title` argument to the popover component for accessibility reasons.
+You can customize the header to add rich content instead of a simple title by calling the `with_header` slot.
 
-```erb{3}
-<%= render(Impulse::PopoverComponent.new(title: "Activity feed")) do |c| %>
+```erb{3-6}
+<%= render(Impulse::PopoverComponent.new) do |c| %>
   <% c.with_trigger { "Toggle popover" } %>
-  <% c.with_header { "Custom header" } %>
+  <% c.with_header do %>
+    <h2>Custom title</h2>
+    <button type="button">Action button</button>
+  <% end %>
   <% c.with_body do %>
     <span>And here's some amazing content. It's very engaging. Right?</span>
   <% end %>
 <% end %>
 ```
+
+::: tip Note
+You are encouraged to use the `title` argument if there aren't any rich content inside the header.
+:::
 
 ### Closing the popover
 
@@ -52,16 +69,18 @@ Add the `data-action="click->awc-popover#hide"` attribute on the `button` elemen
 <% end %>
 ```
 
-### Without header and title
+### Nesting popovers
 
-If you pass `nil` as the `title` argument and avoid calling the `with_header` slot, the popover's header element will
-not be rendered.
+You can nest as many popovers as you want and it will be stacked on top of the parent popover.
 
-```erb{1}
-<%= render(Impulse::PopoverComponent.new(title: nil)) do |c| %>
-  <% c.with_trigger { "Toggle popover" } %>
+```erb{4-7}
+<%= render(Impulse::PopoverComponent.new) do |c| %>
+  <% c.with_trigger { "Open" } %>
   <% c.with_body do %>
-    Header will not be rendered!
+    <%= render(Impulse::PopoverComponent.new) do |c| %>
+      <% c.with_trigger { "Open nested popover" } %>
+      <% c.with_body { "Nested contents" } %>
+    <% end %>
   <% end %>
 <% end %>
 ```

--- a/previews/impulse/popover_component_preview/custom_header.html.erb
+++ b/previews/impulse/popover_component_preview/custom_header.html.erb
@@ -1,4 +1,4 @@
-<%= render(Impulse::PopoverComponent.new(title: "Delete")) do |c| %>
+<%= render(Impulse::PopoverComponent.new) do |c| %>
   <% c.with_trigger(class: "btn btn-primary") { "Toggle popover" } %>
   <% c.with_header(class: "d-flex align-items-center justify-content-between") do %>
     <span>Delete</span>

--- a/test/components/popover_component_test.rb
+++ b/test/components/popover_component_test.rb
@@ -3,20 +3,19 @@ require "test_helper"
 module Impulse
   class PopoverComponentTest < ApplicationTest
     test "renders the component" do
-      render_inline(Impulse::PopoverComponent.new(title: "Activity feed")) do |c|
+      render_inline(Impulse::PopoverComponent.new) do |c|
         c.with_trigger(data: {test_id: "btn"}) { "Toggle popover" }
         c.with_body { "Popover body" }
       end
 
       assert_selector "awc-popover.awc-popover"
+      refute_selector ".popover-header"
+
       assert_selector "[data-test-id='btn']", text: "Toggle popover"
       assert_selector "[data-test-id='btn'][aria-haspopup='dialog']"
       assert_selector "[data-test-id='btn'][aria-expanded='false']"
       assert_selector "[data-test-id='btn'][role='button']"
       assert_selector "[data-test-id='btn'][type='button']"
-
-      assert_selector ".popover-header", text: "Activity feed"
-      assert_selector "button.close[aria-label='Close']"
 
       assert_selector ".popover-body", text: "Popover body"
 
@@ -31,6 +30,16 @@ module Impulse
       assert_selector ".arrow"
     end
 
+    test "renders the title and the close button" do
+      render_inline(Impulse::PopoverComponent.new(title: "Activity feed")) do |c|
+        c.with_trigger(data: {test_id: "btn"}) { "Toggle popover" }
+        c.with_body { "Popover body" }
+      end
+
+      assert_selector ".popover-header", text: "Activity feed"
+      assert_selector "button.close[aria-label='Close']"
+    end
+
     test "renders a custom header" do
       render_inline(Impulse::PopoverComponent.new(title: "Activity feed")) do |c|
         c.with_trigger(data: {test_id: "btn"}) { "Toggle popover" }
@@ -42,16 +51,8 @@ module Impulse
       refute_text "Activity feed"
     end
 
-    test "renders without the header component" do
-      render_inline(Impulse::PopoverComponent.new(title: nil)) do |c|
-        c.with_trigger(data: {test_id: "btn"}) { "Toggle popover" }
-      end
-
-      refute_selector ".popover-header"
-    end
-
     test "disabled popover" do
-      render_inline(Impulse::PopoverComponent.new(title: "Activity feed")) do |c|
+      render_inline(Impulse::PopoverComponent.new) do |c|
         c.with_trigger(disabled: true) { "Toggle popover" }
       end
 
@@ -60,7 +61,7 @@ module Impulse
     end
 
     test "does not render without the button" do
-      render_inline(Impulse::PopoverComponent.new(title: "Activity feed")) do |c|
+      render_inline(Impulse::PopoverComponent.new) do |c|
         c.with_body { "Popover body" }
       end
 
@@ -68,7 +69,7 @@ module Impulse
     end
 
     test "popover body's HTML tag can be changed" do
-      render_inline(Impulse::PopoverComponent.new(title: "Activity feed")) do |c|
+      render_inline(Impulse::PopoverComponent.new) do |c|
         c.with_trigger { "Toggle popover" }
         c.with_body(tag: :article) { "Popover body" }
       end


### PR DESCRIPTION
Previously, you'd have to always pass the `title` argument and set it to `nil` if you didn't want any headers. This has been changed and now will only need to specify the `title` argument if you want to render a header.