### PR TITLE
v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2024-03-01
+
 ### Changed
 
-- Avoid rendering Popover's header by default
-- Use [`popover`](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) API in `PopoverComponent`
+- Avoid rendering Popover's header by default ([#74](https://github.com/Ambiki/impulse_view_components/pull/74))
+- Use [`popover`](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) API in `PopoverComponent` ([#73](https://github.com/Ambiki/impulse_view_components/pull/73))
 
 ### Fixed
 
-- Disabled autocomplete option's description color
+- Disabled autocomplete option's description color ([#85](https://github.com/Ambiki/impulse_view_components/pull/85))
 
 ## [0.3.0] - 2023-12-21
 
@@ -109,7 +111,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Everything!
 
-[unreleased]: https://github.com/Ambiki/impulse_view_components/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/Ambiki/impulse_view_components/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/Ambiki/impulse_view_components/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/Ambiki/impulse_view_components/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Ambiki/impulse_view_components/compare/v0.2.1...v0.2.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    impulse_view_components (0.3.0)
+    impulse_view_components (0.3.1)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.3.0)
+    impulse_view_components (0.3.1)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 
@@ -228,8 +228,6 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2024.1)
-      tzinfo (>= 1.0.0)
     unicode-display_width (2.4.2)
     view_component (3.11.0)
       activesupport (>= 5.2.0, < 8.0)

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.3.0)
+    impulse_view_components (0.3.1)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.3.0)
+    impulse_view_components (0.3.1)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.3.0)
+    impulse_view_components (0.3.1)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/lib/impulse/view_components/version.rb
+++ b/lib/impulse/view_components/version.rb
@@ -1,5 +1,5 @@
 module Impulse
   module ViewComponents
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ambiki/impulse-view-components",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A set of JavaScript patterns and Web Components meant to used with the ImpulseViewComponents gem.",
   "author": "Ambitious Idea Labs <info@ambiki.com> (https://ambiki.com/)",
   "contributors": [


### PR DESCRIPTION
### Changed

- Avoid rendering Popover's header by default ([#74](https://github.com/Ambiki/impulse_view_components/pull/74))
- Use [`popover`](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) API in `PopoverComponent` ([#73](https://github.com/Ambiki/impulse_view_components/pull/73))

### Fixed

- Disabled autocomplete option's description color ([#85](https://github.com/Ambiki/impulse_view_components/pull/85))
