### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2024-04-15
+
 ### Added
 
-- Add `data-text` attribute to autocomplete group container
+- Add `data-text` attribute to autocomplete group container ([#97](https://github.com/Ambiki/impulse_view_components/pull/97))
 
 ### Fixed
 
-- Mark dialog title's margin as important
-- Nested dialog resets `body` padding
-- Inherit `namespace` value from parent `impulse_form_with`
+- Mark dialog title's margin as important ([#102](https://github.com/Ambiki/impulse_view_components/pull/102))
+- Nested dialog resets `body` padding ([#99](https://github.com/Ambiki/impulse_view_components/pull/99))
+- Inherit `namespace` value from parent `impulse_form_with` ([#96](https://github.com/Ambiki/impulse_view_components/pull/96))
 
 ## [0.4.0] - 2024-03-05
 
@@ -127,7 +129,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Everything!
 
-[unreleased]: https://github.com/Ambiki/impulse_view_components/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/Ambiki/impulse_view_components/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Ambiki/impulse_view_components/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.2.3...v0.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    impulse_view_components (0.4.0)
+    impulse_view_components (0.5.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.4.0)
+    impulse_view_components (0.5.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.4.0)
+    impulse_view_components (0.5.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.4.0)
+    impulse_view_components (0.5.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.4.0)
+    impulse_view_components (0.5.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/lib/impulse/view_components/version.rb
+++ b/lib/impulse/view_components/version.rb
@@ -1,5 +1,5 @@
 module Impulse
   module ViewComponents
-    VERSION = "0.4.0".freeze
+    VERSION = "0.5.0".freeze
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ambiki/impulse-view-components",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A set of JavaScript patterns and Web Components meant to used with the ImpulseViewComponents gem.",
   "author": "Ambitious Idea Labs <info@ambiki.com> (https://ambiki.com/)",
   "contributors": [


### PR DESCRIPTION
### Added

- Add `data-text` attribute to autocomplete group container ([#97](https://github.com/Ambiki/impulse_view_components/pull/97))

### Fixed

- Mark dialog title's margin as important ([#102](https://github.com/Ambiki/impulse_view_components/pull/102))
- Nested dialog resets `body` padding ([#99](https://github.com/Ambiki/impulse_view_components/pull/99))
- Inherit `namespace` value from parent `impulse_form_with` ([#96](https://github.com/Ambiki/impulse_view_components/pull/96))
