### PR TITLE
fix(popover): return early if panel is missing [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Return early if panel is not present in `PopoverComponent`
 - Fixes an issue where popover was breaking Chrome 133
 
 ## [0.5.1] - 2024-05-14

--- a/src/elements/popover/index.ts
+++ b/src/elements/popover/index.ts
@@ -150,6 +150,7 @@ export default class AwcPopoverElement extends ImpulseElement {
   }
 
   get open(): boolean {
+    if (!this.panel) return false;
     try {
       return this.panel.matches(':popover-open');
     } catch {


### PR DESCRIPTION
fixed #105 