### PR TITLE
v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-02-07
+
 ### Added
 
-- Cache autocomplete options if they are fetched remotely
+- Cache autocomplete options if they are fetched remotely ([#123](https://github.com/Ambiki/impulse_view_components/pull/123))
 
 ### Fixed
 
-- Return early if panel is not present in `PopoverComponent`
-- Fixes an issue where popover was breaking Chrome 133
+- Return early if panel is not present in `PopoverComponent` ([#134](https://github.com/Ambiki/impulse_view_components/pull/134))
+- Fixes an issue where popover was breaking Chrome 133 ([#131](https://github.com/Ambiki/impulse_view_components/pull/131))
 
 ## [0.5.1] - 2024-05-14
 
@@ -145,7 +147,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Everything!
 
-[unreleased]: https://github.com/Ambiki/impulse_view_components/compare/v0.5.1...HEAD
+[unreleased]: https://github.com/Ambiki/impulse_view_components/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Ambiki/impulse_view_components/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.3.1...v0.4.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    impulse_view_components (0.5.1)
+    impulse_view_components (0.6.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.5.1)
+    impulse_view_components (0.6.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.5.1)
+    impulse_view_components (0.6.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.5.1)
+    impulse_view_components (0.6.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.5.1)
+    impulse_view_components (0.6.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/lib/impulse/view_components/version.rb
+++ b/lib/impulse/view_components/version.rb
@@ -1,5 +1,5 @@
 module Impulse
   module ViewComponents
-    VERSION = "0.5.1".freeze
+    VERSION = "0.6.0".freeze
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ambiki/impulse-view-components",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A set of JavaScript patterns and Web Components meant to used with the ImpulseViewComponents gem.",
   "author": "Ambitious Idea Labs <info@ambiki.com> (https://ambiki.com/)",
   "contributors": [


### PR DESCRIPTION
### Added

- Cache autocomplete options if they are fetched remotely ([#123](https://github.com/Ambiki/impulse_view_components/pull/123))

### Fixed

- Return early if panel is not present in `PopoverComponent` ([#134](https://github.com/Ambiki/impulse_view_components/pull/134))
- Fixes an issue where popover was breaking Chrome 133 ([#131](https://github.com/Ambiki/impulse_view_components/pull/131))
