### PR TITLE
fix(autocomplete): avoid removing loading error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Remote autocomplete should not remove the `loading` attribute on `AbortError`
+
 ## [0.6.0] - 2025-02-07
 
 ### Added

--- a/src/elements/autocomplete/remote_search.ts
+++ b/src/elements/autocomplete/remote_search.ts
@@ -56,16 +56,20 @@ export default class RemoteSearch {
         await this.insertOptions(options);
         this.abortController = undefined;
         this.emit('load');
+
+        this.autocomplete.removeAttribute('loading');
+        this.emit('loadend');
       } else {
-        throw new Error();
+        throw new Error(await response.text());
       }
     } catch (error) {
-      if (error instanceof Error && error.name !== 'AbortError') {
-        this.abortController = undefined;
-        this.autocomplete.setAttribute('error', '');
-        this.emit('error');
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
       }
-    } finally {
+
+      this.abortController = undefined;
+      this.autocomplete.setAttribute('error', '');
+      this.emit('error');
       this.autocomplete.removeAttribute('loading');
       this.emit('loadend');
     }


### PR DESCRIPTION
We should not remove the `loading` attribute on `AbortError`.