### PR TITLE
fix(autocomplete): clear cache when `src` changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Clear autocomplete cache when `src` changes
 - Return early if popup element is not defined in `useFloatingUI`
 - Remote autocomplete should not remove the `loading` attribute on `AbortError`
 

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -144,6 +144,16 @@ export default class AwcAutocompleteElement extends ImpulseElement {
 
   /**
    * @private
+   * Called when the `src` attribute changes.
+   */
+  srcChanged(src: string) {
+    // Clear the selected value without emitting any events to avoid invalid combinations.
+    this.clear();
+    this.searchVariant = src ? new RemoteSearch(this) : new LocalSearch(this);
+  }
+
+  /**
+   * @private
    */
   handleMousedown(event: Event) {
     // Fix focus jitter issue when clicking outside the input element.


### PR DESCRIPTION
fixes #147