### PR TITLE
v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2025-07-04
+
 ### Added
 
-- Dynamically adjust autocomplete's height
-- Add `value` and `text` property to the autocomplete `remove` event
-- Add `value` and `text` property to the autocomplete `commit` event
+- Dynamically adjust autocomplete's height ([#159](https://github.com/Ambiki/impulse_view_components/pull/159))
+- Add `value` and `text` property to the autocomplete `remove` event ([#152](https://github.com/Ambiki/impulse_view_components/pull/152))
+- Add `value` and `text` property to the autocomplete `commit` event ([#151](https://github.com/Ambiki/impulse_view_components/pull/151))
 
 ### Fixed
 
-- Clear autocomplete cache when `src` changes
-- Return early if popup element is not defined in `useFloatingUI`
-- Remote autocomplete should not remove the `loading` attribute on `AbortError`
+- Clear autocomplete cache when `src` changes ([#153](https://github.com/Ambiki/impulse_view_components/pull/153))
+- Return early if popup element is not defined in `useFloatingUI` ([#146](https://github.com/Ambiki/impulse_view_components/pull/146))
+- Remote autocomplete should not remove the `loading` attribute on `AbortError` ([#139](https://github.com/Ambiki/impulse_view_components/pull/139))
 
 ## [0.6.0] - 2025-02-07
 
@@ -159,7 +161,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Everything!
 
-[unreleased]: https://github.com/Ambiki/impulse_view_components/compare/v0.6.0...HEAD
+[unreleased]: https://github.com/Ambiki/impulse_view_components/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Ambiki/impulse_view_components/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.4.0...v0.5.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    impulse_view_components (0.6.0)
+    impulse_view_components (0.7.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.6.0)
+    impulse_view_components (0.7.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/docs/components/ajax-select.md
+++ b/docs/components/ajax-select.md
@@ -21,20 +21,22 @@ Ajax select allows users to fetch a list of options from the server.
 
 ### Keyword arguments
 
-| Name           | Default   | Description                                                                                                                                      |
-| ------         | --------- | -------------                                                                                                                                    |
-| selected       | `nil`     | The `class` instance that should respond to the `value_method` and `text_method` as defined in the positional arguments.                         |
-| src            | `nil`     | The endpoint to fetch the options from.                                                                                                          |
-| param          | `q`       | The param that is appended when making a network request. Example: `/fruits?q=Guava`.                                                            |
-| size           | `md`      | The size of the select control. One of `sm`, `md`, or `lg`.                                                                                      |
-| name           | `nil`     | The name of the field. By default rails will automatically create a `name` string based on the `object_name` and `method_name`.                  |
-| input_id       | `nil`     | The id of the input field.                                                                                                                       |
-| placeholder    | `nil`     | The placeholder text that is displayed within the input field.                                                                                   |
-| include_hidden | `true`    | See the "Gotcha" section of rails [`select`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select) tag. |
-| disabled       | `false`   | Disables the select control.                                                                                                                     |
-| required       | `false`   | Makes the select control a required field.                                                                                                       |
-| multiple       | `false`   | Whether multiple values can be selected or not.                                                                                                  |
-| clearable      | `true`    | Whether the clear button should be shown or not.                                                                                                 |
+| Name              | Default   | Description                                                                                                                                       |
+| ------            | --------- | -------------                                                                                                                                     |
+| selected          | `nil`     | The `class` instance that should respond to the `value_method` and `text_method` as defined in the positional arguments.                          |
+| src               | `nil`     | The endpoint to fetch the options from.                                                                                                           |
+| param             | `q`       | The param that is appended when making a network request. Example: `/fruits?q=Guava`.                                                             |
+| size              | `md`      | The size of the select control. One of `sm`, `md`, or `lg`.                                                                                       |
+| name              | `nil`     | The name of the field. By default rails will automatically create a `name` string based on the `object_name` and `method_name`.                   |
+| input_id          | `nil`     | The id of the input field.                                                                                                                        |
+| placeholder       | `nil`     | The placeholder text that is displayed within the input field.                                                                                    |
+| include_hidden    | `true`    | See the "Gotcha" section of rails [`select`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select) tag.  |
+| disabled          | `false`   | Disables the select control.                                                                                                                      |
+| required          | `false`   | Makes the select control a required field.                                                                                                        |
+| multiple          | `false`   | Whether multiple values can be selected or not.                                                                                                   |
+| clearable         | `true`    | Whether the clear button should be shown or not.                                                                                                  |
+| auto_size         | `true`    | If `true`, the listbox will automatically adjust its height based on its content. This helps avoid scrollbars by fitting the content dynamically. |
+| auto_size_padding | `4`       | The number of pixels of extra space to add beyond the content's height when `auto_size` is enabled. Acts as vertical padding.                     |
 
 ::: tip Note
 The server response should include the options that matched the search query.

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -20,18 +20,20 @@ Select allows a user to filter through a list of pre-defined sets of options and
 
 ### Keyword arguments
 
-| Name           | Default   | Description                                                                                                                                      |
-| ------         | --------- | -------------                                                                                                                                    |
-| selected       | `nil`     | The `value` of the option that you want to force select.                                                                                         |
-| size           | `md`      | The size of the select control. One of `sm`, `md`, or `lg`.                                                                                      |
-| name           | `nil`     | The name of the field. By default rails will automatically create a `name` string based on the `object_name` and `method_name`.                  |
-| input_id       | `nil`     | The id of the input field.                                                                                                                       |
-| placeholder    | `nil`     | The placeholder text that is displayed within the input field.                                                                                   |
-| include_hidden | `true`    | See the "Gotcha" section of rails [`select`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select) tag. |
-| disabled       | `false`   | Disables the select control.                                                                                                                     |
-| required       | `false`   | Makes the select control a required field.                                                                                                       |
-| multiple       | `false`   | Whether multiple values can be selected or not.                                                                                                  |
-| clearable      | `true`    | Whether the clear button should be shown or not.                                                                                                 |
+| Name              | Default   | Description                                                                                                                                       |
+| ------            | --------- | -------------                                                                                                                                     |
+| selected          | `nil`     | The `value` of the option that you want to force select.                                                                                          |
+| size              | `md`      | The size of the select control. One of `sm`, `md`, or `lg`.                                                                                       |
+| name              | `nil`     | The name of the field. By default rails will automatically create a `name` string based on the `object_name` and `method_name`.                   |
+| input_id          | `nil`     | The id of the input field.                                                                                                                        |
+| placeholder       | `nil`     | The placeholder text that is displayed within the input field.                                                                                    |
+| include_hidden    | `true`    | See the "Gotcha" section of rails [`select`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select) tag.  |
+| disabled          | `false`   | Disables the select control.                                                                                                                      |
+| required          | `false`   | Makes the select control a required field.                                                                                                        |
+| multiple          | `false`   | Whether multiple values can be selected or not.                                                                                                   |
+| clearable         | `true`    | Whether the clear button should be shown or not.                                                                                                  |
+| auto_size         | `true`    | If `true`, the listbox will automatically adjust its height based on its content. This helps avoid scrollbars by fitting the content dynamically. |
+| auto_size_padding | `4`       | The number of pixels of extra space to add beyond the content's height when `auto_size` is enabled. Acts as vertical padding.                     |
 
 ## Examples
 

--- a/docs/components/time-zone-select.md
+++ b/docs/components/time-zone-select.md
@@ -35,6 +35,8 @@ Time zone select allows a user to filter through a list of default time zones an
 | required             | `false`                   | Makes the select control a required field.                                                                                                                                                                                                       |
 | multiple             | `false`                   | Whether multiple values can be selected or not.                                                                                                                                                                                                  |
 | clearable            | `true`                    | Whether the clear button should be shown or not.                                                                                                                                                                                                 |
+| auto_size            | `true`                    | If `true`, the listbox will automatically adjust its height based on its content. This helps avoid scrollbars by fitting the content dynamically.                                                                                                |
+| auto_size_padding    | `4`                       | The number of pixels of extra space to add beyond the content's height when `auto_size` is enabled. Acts as vertical padding.                                                                                                                    |
 
 ## Examples
 

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.6.0)
+    impulse_view_components (0.7.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.6.0)
+    impulse_view_components (0.7.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.6.0)
+    impulse_view_components (0.7.0)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/lib/impulse/view_components/version.rb
+++ b/lib/impulse/view_components/version.rb
@@ -1,5 +1,5 @@
 module Impulse
   module ViewComponents
-    VERSION = "0.6.0".freeze
+    VERSION = "0.7.0".freeze
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ambiki/impulse-view-components",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A set of JavaScript patterns and Web Components meant to used with the ImpulseViewComponents gem.",
   "author": "Ambitious Idea Labs <info@ambiki.com> (https://ambiki.com/)",
   "contributors": [


### PR DESCRIPTION
### Added

- Dynamically adjust autocomplete's height ([#159](https://github.com/Ambiki/impulse_view_components/pull/159))
- Add `value` and `text` property to the autocomplete `remove` event ([#152](https://github.com/Ambiki/impulse_view_components/pull/152))
- Add `value` and `text` property to the autocomplete `commit` event ([#151](https://github.com/Ambiki/impulse_view_components/pull/151))

### Fixed

- Clear autocomplete cache when `src` changes ([#153](https://github.com/Ambiki/impulse_view_components/pull/153))
- Return early if popup element is not defined in `useFloatingUI` ([#146](https://github.com/Ambiki/impulse_view_components/pull/146))
- Remote autocomplete should not remove the `loading` attribute on `AbortError` ([#139](https://github.com/Ambiki/impulse_view_components/pull/139))