### PR TITLE
V0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.7.1] - 2025-07-04
+
+### Fixed
+
+- Fixed SCSS compile issues when using the `min` CSS function ([#165](https://github.com/Ambiki/impulse_view_components/pull/165))
+
 ## [0.7.0] - 2025-07-04
 
 ### Added
@@ -161,7 +167,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Everything!
 
-[unreleased]: https://github.com/Ambiki/impulse_view_components/compare/v0.7.0...HEAD
+[unreleased]: https://github.com/Ambiki/impulse_view_components/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/Ambiki/impulse_view_components/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Ambiki/impulse_view_components/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Ambiki/impulse_view_components/compare/v0.5.0...v0.5.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    impulse_view_components (0.7.0)
+    impulse_view_components (0.7.1)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.7.0)
+    impulse_view_components (0.7.1)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.7.0)
+    impulse_view_components (0.7.1)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.7.0)
+    impulse_view_components (0.7.1)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    impulse_view_components (0.7.0)
+    impulse_view_components (0.7.1)
       actionview (>= 6.1.0)
       view_component (~> 3.11)
 

--- a/lib/impulse/view_components/version.rb
+++ b/lib/impulse/view_components/version.rb
@@ -1,5 +1,5 @@
 module Impulse
   module ViewComponents
-    VERSION = "0.7.0".freeze
+    VERSION = "0.7.1".freeze
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ambiki/impulse-view-components",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A set of JavaScript patterns and Web Components meant to used with the ImpulseViewComponents gem.",
   "author": "Ambitious Idea Labs <info@ambiki.com> (https://ambiki.com/)",
   "contributors": [

--- a/src/elements/autocomplete/index.scss
+++ b/src/elements/autocomplete/index.scss
@@ -108,9 +108,8 @@
 
 .awc-autocomplete-listbox {
   font-size: var(--awc-autocomplete-listbox-font-size);
-  max-height: min(
-    var(--awc-autocomplete-listbox-max-height),
-    var(--awc-auto-size-height, var(--awc-autocomplete-listbox-max-height))
+  max-height: unquote(
+    'min(var(--awc-autocomplete-listbox-max-height), var(--awc-auto-size-height, var(--awc-autocomplete-listbox-max-height)))'
   );
   overflow: hidden auto;
   box-shadow: var(--shadow-md);


### PR DESCRIPTION
### Fixed

- Fixed SCSS compile issues when using the `min` CSS function ([#165](https://github.com/Ambiki/impulse_view_components/pull/165))
