### PR TITLE
fix: use AbortController to tear down useOutsideClick listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed `useOutsideClick` leaking its `click` listener by switching teardown to `AbortController` (PR_LINK)
+- Fixed `useOutsideClick` leaking its `click` listener by switching teardown to `AbortController` ([#215](https://github.com/Ambiki/impulse_view_components/pull/215))
 
 ## [0.8.0] - 2026-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `useOutsideClick` leaking its `click` listener by switching teardown to `AbortController` (PR_LINK)
+
 ## [0.8.0] - 2026-01-09
 
 ### Changed

--- a/src/hooks/use_outside_click.ts
+++ b/src/hooks/use_outside_click.ts
@@ -8,6 +8,9 @@ type UseOutsideClickOptions = {
 };
 
 export default function useOutsideClick(element: ImpulseElement, { boundaries, callback }: UseOutsideClickOptions) {
+  const controller = new AbortController();
+  const { signal } = controller;
+
   let initialClickTarget: HTMLElement | null = null;
 
   function setInitialClickTarget(event: Event) {
@@ -33,13 +36,15 @@ export default function useOutsideClick(element: ImpulseElement, { boundaries, c
     initialClickTarget = null;
   }
 
-  document.addEventListener('mousedown', setInitialClickTarget, true);
-  document.addEventListener('click', (event) => handleOutsideClick(event, () => initialClickTarget), true);
+  document.addEventListener('mousedown', setInitialClickTarget, { capture: true, signal });
+  document.addEventListener('click', (event) => handleOutsideClick(event, () => initialClickTarget), {
+    capture: true,
+    signal,
+  });
 
   function destroy() {
     initialClickTarget = null;
-    document.removeEventListener('mousedown', setInitialClickTarget, true);
-    document.removeEventListener('click', (event) => handleOutsideClick(event, () => initialClickTarget), true);
+    controller.abort();
   }
 
   const disconnectedCallback = element.disconnected.bind(element);


### PR DESCRIPTION
## Summary

`useOutsideClick` registered two capture-phase document listeners (`mousedown` + `click`) and tore them down in `destroy()`. The `click` listener was added with an inline arrow function and removed with a **different** arrow function instance — since `removeEventListener` matches by reference, that call was a no-op and the listener leaked for the document's lifetime after the element disconnected.

This switches teardown to an `AbortController`, removing both listeners atomically via a single `controller.abort()`. It also matches the pattern already used in `src/helpers/focus_trap.ts` and `src/helpers/scroll_lock.ts`.

Neither consumer (`popover`, `autocomplete`) uses the hook's return value, so no caller changes were needed.

## Verification

- `npx tsc --noEmit` passes
- `eslint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)