### PR TITLE
feat: add GlobalEventHandlersEventMap entries for dialog and popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `GlobalEventHandlersEventMap` entries for the dialog and popover events so listeners receive a typed `CustomEvent` ([#216](https://github.com/Ambiki/impulse_view_components/pull/216))
+
 ### Fixed
 
 - Fixed `useOutsideClick` leaking its `click` listener by switching teardown to `AbortController` ([#215](https://github.com/Ambiki/impulse_view_components/pull/215))

--- a/src/elements/dialog/index.ts
+++ b/src/elements/dialog/index.ts
@@ -113,4 +113,7 @@ declare global {
   interface HTMLElementTagNameMap {
     'awc-dialog': AwcDialogElement;
   }
+  interface GlobalEventHandlersEventMap {
+    'awc-dialog:hidden': CustomEvent<Record<string, never>>;
+  }
 }

--- a/src/elements/popover/index.ts
+++ b/src/elements/popover/index.ts
@@ -172,4 +172,10 @@ declare global {
   interface HTMLElementTagNameMap {
     'awc-popover': AwcPopoverElement;
   }
+  interface GlobalEventHandlersEventMap {
+    'awc-popover:hide': CustomEvent<Record<string, never>>;
+    'awc-popover:hidden': CustomEvent<Record<string, never>>;
+    'awc-popover:show': CustomEvent<Record<string, never>>;
+    'awc-popover:shown': CustomEvent<Record<string, never>>;
+  }
 }


### PR DESCRIPTION
## Summary

Augments the global `GlobalEventHandlersEventMap` interface for the `awc-dialog` and `awc-popover` custom elements — matching the existing pattern in `awc-autocomplete`. Listeners for their emitted events are now type-checked and receive a correctly typed `CustomEvent`.

- **dialog**: `awc-dialog:hidden`
- **popover**: `awc-popover:hide`, `awc-popover:hidden`, `awc-popover:show`, `awc-popover:shown`

These events carry no `detail` payload, so they map to `CustomEvent<Record<string, never>>` (impulse's `emit` defaults `detail` to an empty object `{}`).

## Test plan

- `npx tsc --noEmit` passes
- `addEventListener('awc-popover:shown', e => …)` now resolves `e` to the typed `CustomEvent`; unknown keys error

🤖 Generated with [Claude Code](https://claude.com/claude-code)