### PR TITLE
feat: infer autocomplete types from selection mode and source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Autocomplete now infers its API types from the selection mode and source: `value`/`removeValue` resolve by narrowing on `multiple`, and `setValue`'s `text` requirement by narrowing on the new `remote` getter. Exported `SingleAutocompleteElement` / `MultipleAutocompleteElement` / `LocalAutocompleteElement` / `RemoteAutocompleteElement` types allow pinning the shape explicitly ([#217](https://github.com/Ambiki/impulse_view_components/pull/217))
 - Added `GlobalEventHandlersEventMap` entries for the dialog and popover events so listeners receive a typed `CustomEvent` ([#216](https://github.com/Ambiki/impulse_view_components/pull/216))
 
 ### Fixed

--- a/docs/js-api/autocomplete.md
+++ b/docs/js-api/autocomplete.md
@@ -56,6 +56,17 @@ const local = document.querySelector<LocalAutocompleteElement>('awc-autocomplete
 local.setValue('1'); // text is optional
 ```
 
+Each alias leaves the other dimension open, but they are composable — pass the other dimension as a
+type argument to pin both at once:
+
+```ts
+const el = document.querySelector<MultipleAutocompleteElement<'remote'>>('awc-autocomplete')!;
+el.value; // string[]
+el.setValue('1', 'One'); // text is required
+
+// `RemoteAutocompleteElement<'multiple'>` resolves to the same type.
+```
+
 ## Methods
 
 ### `open`

--- a/docs/js-api/autocomplete.md
+++ b/docs/js-api/autocomplete.md
@@ -7,8 +7,9 @@ const autocomplete = document.querySelector('awc-autocomplete');
 ## TypeScript
 
 The selection mode (single vs. multiple) determines the type of `value` and the arguments
-`removeValue` accepts. TypeScript resolves these automatically when you narrow on the `multiple`
-property:
+`removeValue` accepts, and the source (local vs. remote) determines whether `setValue` requires
+the `text` argument. TypeScript resolves these automatically when you narrow on the `multiple` and
+`remote` properties:
 
 ```ts
 const autocomplete = document.querySelector('awc-autocomplete')!;
@@ -19,6 +20,12 @@ if (autocomplete.multiple) {
 } else {
   autocomplete.value; // string
   autocomplete.removeValue(); // no argument
+}
+
+if (autocomplete.remote) {
+  autocomplete.setValue('1', 'One'); // text is required
+} else {
+  autocomplete.setValue('1'); // text is optional
 }
 ```
 
@@ -38,9 +45,8 @@ const single = document.querySelector<SingleAutocompleteElement>('awc-autocomple
 single.value; // string
 ```
 
-The source (local vs. remote) determines whether `setValue` requires the `text` argument. Because
-this is driven by the `src` attribute (a string) rather than a boolean, opt into the strict typing
-by querying as `RemoteAutocompleteElement` (or `LocalAutocompleteElement`):
+If you already know the source at the call site, you can also pass the exported type to
+`querySelector` instead of narrowing on `remote`:
 
 ```ts
 import type {
@@ -107,6 +113,16 @@ autocomplete.value;
 // Single select
 autocomplete.value;
 // => '1'
+```
+
+### `remote`
+
+Whether the options are fetched from a remote source (i.e. the `src` attribute is set). Narrowing
+on this resolves source-dependent types — see [TypeScript](#typescript).
+
+```js
+autocomplete.remote;
+// => true
 ```
 
 ### `setValue`
@@ -225,17 +241,17 @@ autocomplete.form;
 
 ## Events
 
-| Name                      | Bubbles   | Description                                                                                                                                                                            |
-| ------                    | --------- | ------------                                                                                                                                                                           |
-| `awc-autocomplete:show`   | `true`    | This event fires immediately when the `open` attribute is added.                                                                                                                       |
-| `awc-autocomplete:shown`  | `true`    | This event fires when the listbox has been made visible to the user.                                                                                                                   |
-| `awc-autocomplete:hide`   | `true`    | This event fires immediately when the `open` attribute is removed.                                                                                                                     |
-| `awc-autocomplete:hidden` | `true`    | This event fires when the listbox has been completely hidden from the user.                                                                                                            |
-| `awc-autocomplete:commit` | `true`    | This event fires when an option is selected or deselected by clicking the option element. You can access the committed option, its value, and its text from the `event.detail` object. |
-| `awc-autocomplete:clear`  | `true`    | This event fires when all the selected options have been deselected by clicking on the "Clear" button.                                                                                 |
-| `awc-autocomplete:remove` | `true`    | This event fires when a tag has been removed. You can access the removed tag, its value, and its text from the `event.detail` object.                                                  |
-| `awc-autocomplete:reset`  | `true`    | This event fires when the parent form has been reset.                                                                                                                                  |
-| `loadstart`               | `false`   | This event fires when the autocomplete starts the network request.                                                                                                                     |
-| `load`                    | `false`   | This event fires when the autocomplete fetches the options successfully from the server.                                                                                               |
-| `error`                   | `false`   | This event fires when the autocomplete fails to fetch the options from the server.                                                                                                     |
-| `loadend`                 | `false`   | This event fires when the autocomplete finishes the network request.                                                                                                                   |
+| Name                      | Bubbles | Description                                                                                                                                                                            |
+| ------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `awc-autocomplete:show`   | `true`  | This event fires immediately when the `open` attribute is added.                                                                                                                       |
+| `awc-autocomplete:shown`  | `true`  | This event fires when the listbox has been made visible to the user.                                                                                                                   |
+| `awc-autocomplete:hide`   | `true`  | This event fires immediately when the `open` attribute is removed.                                                                                                                     |
+| `awc-autocomplete:hidden` | `true`  | This event fires when the listbox has been completely hidden from the user.                                                                                                            |
+| `awc-autocomplete:commit` | `true`  | This event fires when an option is selected or deselected by clicking the option element. You can access the committed option, its value, and its text from the `event.detail` object. |
+| `awc-autocomplete:clear`  | `true`  | This event fires when all the selected options have been deselected by clicking on the "Clear" button.                                                                                 |
+| `awc-autocomplete:remove` | `true`  | This event fires when a tag has been removed. You can access the removed tag, its value, and its text from the `event.detail` object.                                                  |
+| `awc-autocomplete:reset`  | `true`  | This event fires when the parent form has been reset.                                                                                                                                  |
+| `loadstart`               | `false` | This event fires when the autocomplete starts the network request.                                                                                                                     |
+| `load`                    | `false` | This event fires when the autocomplete fetches the options successfully from the server.                                                                                               |
+| `error`                   | `false` | This event fires when the autocomplete fails to fetch the options from the server.                                                                                                     |
+| `loadend`                 | `false` | This event fires when the autocomplete finishes the network request.                                                                                                                   |

--- a/docs/js-api/autocomplete.md
+++ b/docs/js-api/autocomplete.md
@@ -38,6 +38,24 @@ const single = document.querySelector<SingleAutocompleteElement>('awc-autocomple
 single.value; // string
 ```
 
+The source (local vs. remote) determines whether `setValue` requires the `text` argument. Because
+this is driven by the `src` attribute (a string) rather than a boolean, opt into the strict typing
+by querying as `RemoteAutocompleteElement` (or `LocalAutocompleteElement`):
+
+```ts
+import type {
+  RemoteAutocompleteElement,
+  LocalAutocompleteElement,
+} from '@ambiki/impulse-view-components/dist/elements/autocomplete';
+
+const remote = document.querySelector<RemoteAutocompleteElement>('awc-autocomplete')!;
+remote.setValue('1', 'One'); // text is required
+remote.setValue('1'); // ✗ type error
+
+const local = document.querySelector<LocalAutocompleteElement>('awc-autocomplete')!;
+local.setValue('1'); // text is optional
+```
+
 ## Methods
 
 ### `open`
@@ -82,7 +100,9 @@ autocomplete.value;
 
 ### `setValue`
 
-Sets the value of the element.
+Sets the value of the element. When the options are fetched from a remote source, the `text`
+argument is required (the option is not in the DOM, so its text cannot be derived); for local
+options it is optional. See [TypeScript](#typescript) for how to enforce this at compile time.
 
 ```js
 autocomplete.setValue('apple', 'Apple');

--- a/docs/js-api/autocomplete.md
+++ b/docs/js-api/autocomplete.md
@@ -4,6 +4,40 @@
 const autocomplete = document.querySelector('awc-autocomplete');
 ```
 
+## TypeScript
+
+The selection mode (single vs. multiple) determines the type of `value` and the arguments
+`removeValue` accepts. TypeScript resolves these automatically when you narrow on the `multiple`
+property:
+
+```ts
+const autocomplete = document.querySelector('awc-autocomplete')!;
+
+if (autocomplete.multiple) {
+  autocomplete.value; // string[]
+  autocomplete.removeValue('1'); // value argument is required
+} else {
+  autocomplete.value; // string
+  autocomplete.removeValue(); // no argument
+}
+```
+
+If you already know the mode at the call site, pass the exported type to `querySelector` instead
+of narrowing:
+
+```ts
+import type {
+  SingleAutocompleteElement,
+  MultipleAutocompleteElement,
+} from '@ambiki/impulse-view-components/dist/elements/autocomplete';
+
+const multi = document.querySelector<MultipleAutocompleteElement>('awc-autocomplete')!;
+multi.value; // string[]
+
+const single = document.querySelector<SingleAutocompleteElement>('awc-autocomplete')!;
+single.value; // string
+```
+
 ## Methods
 
 ### `open`
@@ -33,11 +67,17 @@ autocomplete.hide();
 
 ### `value`
 
-Returns all the selected values.
+Returns the selected value(s). For a single select this is a `string`; for a multiple select it
+is a `string[]`.
 
 ```js
+// Multiple select
 autocomplete.value;
 // => ['1', '2']
+
+// Single select
+autocomplete.value;
+// => '1'
 ```
 
 ### `setValue`
@@ -66,7 +106,9 @@ autocomplete.value;
 ```
 
 ::: tip
-You do not have to provide the argument to `removeValue` if the element is a single select.
+The `value` argument is required for a multiple select and is not used by a single select (which
+clears its value when `removeValue()` is called). TypeScript enforces this when the mode is known —
+see [TypeScript](#typescript).
 :::
 
 ### `activate`

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -17,8 +17,17 @@ interface BaseOptionEvent {
 export interface AwcAutocompleteCommitEvent extends BaseOptionEvent {}
 export interface AwcAutocompleteRemoveEvent extends BaseOptionEvent {}
 
+/** Resolves the `value` type based on the selection mode. */
+export type AutocompleteValue<Multiple extends boolean> = Multiple extends true ? string[] : string;
+
+/** Resolves the `removeValue` arguments: required for multi-select, none for single-select. */
+type RemoveValueArgs<Multiple extends boolean> = Multiple extends true ? [value: string] : [];
+
+/** Resolves the select variant based on the selection mode. */
+type SelectVariant<Multiple extends boolean> = Multiple extends true ? MultipleSelect : SingleSelect;
+
 @registerElement('awc-autocomplete')
-export default class AwcAutocompleteElement extends ImpulseElement {
+export default class AwcAutocompleteElement<Multiple extends boolean = boolean> extends ImpulseElement {
   /**
    * Shows/hides the listbox element.
    */
@@ -37,7 +46,7 @@ export default class AwcAutocompleteElement extends ImpulseElement {
   /**
    * Whether multiple values can be selected or not.
    */
-  @property({ type: Boolean }) multiple = false;
+  @property({ type: Boolean }) multiple = false as Multiple;
 
   /**
    * The endpoint to fetch the options from.
@@ -71,7 +80,7 @@ export default class AwcAutocompleteElement extends ImpulseElement {
   @targets() groups: HTMLElement[];
 
   combobox: Combobox;
-  selectVariant: SingleSelect | MultipleSelect;
+  selectVariant: SelectVariant<Multiple>;
   private searchVariant: LocalSearch | RemoteSearch;
   private floatingUI: UseFloatingUIType;
   private firstFocus = true;
@@ -115,7 +124,7 @@ export default class AwcAutocompleteElement extends ImpulseElement {
     });
 
     this.combobox = new Combobox(this.input, this.listbox, { multiple: this.multiple });
-    this.selectVariant = this.multiple ? new MultipleSelect(this) : new SingleSelect(this);
+    this.selectVariant = (this.multiple ? new MultipleSelect(this) : new SingleSelect(this)) as SelectVariant<Multiple>;
     this.selectVariant.connected();
     this.searchVariant = this.src ? new RemoteSearch(this) : new LocalSearch(this);
     this.selectVariant.required = this.required;
@@ -363,9 +372,10 @@ export default class AwcAutocompleteElement extends ImpulseElement {
    * Removes a value from the element.
    * @param value - The value of the option (you do not have to provide the value arg for a single select).
    */
-  removeValue(value?: string) {
-    if (this.multiple && value) {
-      (this.selectVariant as MultipleSelect).removeValue(value);
+  removeValue(...args: RemoveValueArgs<Multiple>) {
+    const [value] = args as [string?];
+    if (this.selectVariant instanceof MultipleSelect && value) {
+      this.selectVariant.removeValue(value);
       return;
     }
 
@@ -434,7 +444,8 @@ export default class AwcAutocompleteElement extends ImpulseElement {
   private removeTag(tag: HTMLElement) {
     const value = tag.getAttribute('value');
     if (!value) return;
-    this.removeValue(value);
+    // Tags only exist in multi-select mode, so the value argument is always required here.
+    (this as AwcAutocompleteElement<true>).removeValue(value);
   }
 
   /**
@@ -454,11 +465,12 @@ export default class AwcAutocompleteElement extends ImpulseElement {
   /**
    * Returns the selected value.
    */
-  get value(): string | string[] {
+  get value(): AutocompleteValue<Multiple> {
     if (this.multiple) {
-      return this.tags.map((tag) => tag.getAttribute('value') ?? '');
+      return this.tags.map((tag) => tag.getAttribute('value') ?? '') as AutocompleteValue<Multiple>;
     }
-    return this.querySelector<HTMLInputElement>('input[data-behavior="hidden-field"]')?.value ?? '';
+    return (this.querySelector<HTMLInputElement>('input[data-behavior="hidden-field"]')?.value ??
+      '') as AutocompleteValue<Multiple>;
   }
 
   /**
@@ -497,12 +509,15 @@ export default class AwcAutocompleteElement extends ImpulseElement {
   }
 }
 
+export type SingleAutocompleteElement = AwcAutocompleteElement<false>;
+export type MultipleAutocompleteElement = AwcAutocompleteElement<true>;
+
 declare global {
   interface Window {
     AwcAutocompleteElement: typeof AwcAutocompleteElement;
   }
   interface HTMLElementTagNameMap {
-    'awc-autocomplete': AwcAutocompleteElement;
+    'awc-autocomplete': SingleAutocompleteElement | MultipleAutocompleteElement;
   }
   interface GlobalEventHandlersEventMap {
     'awc-autocomplete:commit': CustomEvent<AwcAutocompleteCommitEvent>;

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -17,17 +17,26 @@ interface BaseOptionEvent {
 export interface AwcAutocompleteCommitEvent extends BaseOptionEvent {}
 export interface AwcAutocompleteRemoveEvent extends BaseOptionEvent {}
 
+/** Whether multiple values can be selected. */
+export type SelectionMode = 'single' | 'multiple';
+
+/** Where the options come from: the DOM (`local`) or a remote endpoint (`remote`). */
+export type Source = 'local' | 'remote';
+
+/** Resolves the runtime `multiple` property type from the selection mode. */
+type IsMultiple<Mode extends SelectionMode> = Mode extends 'multiple' ? true : false;
+
 /** Resolves the `value` type based on the selection mode. */
-export type AutocompleteValue<Multiple extends boolean> = Multiple extends true ? string[] : string;
+export type AutocompleteValue<Mode extends SelectionMode> = Mode extends 'multiple' ? string[] : string;
 
 /** Resolves the `removeValue` arguments: required for multi-select, none for single-select. */
-type RemoveValueArgs<Multiple extends boolean> = Multiple extends true ? [value: string] : [];
+type RemoveValueArgs<Mode extends SelectionMode> = Mode extends 'multiple' ? [value: string] : [];
 
 /** Resolves the `setValue` text argument: required for a remote source, optional otherwise. */
-type SetValueTextArgs<Remote extends boolean> = Remote extends true ? [text: string] : [text?: string];
+type SetValueTextArgs<Src extends Source> = Src extends 'remote' ? [text: string] : [text?: string];
 
 /** Resolves the select variant based on the selection mode. */
-type SelectVariant<Multiple extends boolean> = Multiple extends true ? MultipleSelect : SingleSelect;
+type SelectVariant<Mode extends SelectionMode> = Mode extends 'multiple' ? MultipleSelect : SingleSelect;
 
 /** The contract implemented by the local and remote search variants. */
 export interface SearchVariant {
@@ -38,8 +47,8 @@ export interface SearchVariant {
 
 @registerElement('awc-autocomplete')
 export default class AwcAutocompleteElement<
-  Multiple extends boolean = boolean,
-  Remote extends boolean = boolean,
+  Mode extends SelectionMode = SelectionMode,
+  Src extends Source = Source,
 > extends ImpulseElement {
   /**
    * Shows/hides the listbox element.
@@ -59,7 +68,7 @@ export default class AwcAutocompleteElement<
   /**
    * Whether multiple values can be selected or not.
    */
-  @property({ type: Boolean }) multiple = false as Multiple;
+  @property({ type: Boolean }) multiple: IsMultiple<Mode> = false as IsMultiple<Mode>;
 
   /**
    * The endpoint to fetch the options from.
@@ -93,7 +102,7 @@ export default class AwcAutocompleteElement<
   @targets() groups: HTMLElement[];
 
   combobox: Combobox;
-  selectVariant: SelectVariant<Multiple>;
+  selectVariant: SelectVariant<Mode>;
   private searchVariant: SearchVariant;
   private floatingUI: UseFloatingUIType;
   private firstFocus = true;
@@ -137,7 +146,7 @@ export default class AwcAutocompleteElement<
     });
 
     this.combobox = new Combobox(this.input, this.listbox, { multiple: this.multiple });
-    this.selectVariant = (this.multiple ? new MultipleSelect(this) : new SingleSelect(this)) as SelectVariant<Multiple>;
+    this.selectVariant = (this.multiple ? new MultipleSelect(this) : new SingleSelect(this)) as SelectVariant<Mode>;
     this.selectVariant.connected();
     this.searchVariant = this.src ? new RemoteSearch(this) : new LocalSearch(this);
     this.selectVariant.required = this.required;
@@ -375,7 +384,7 @@ export default class AwcAutocompleteElement<
    * @param value - The value of the option.
    * @param text - The text of the option.
    */
-  setValue(value: string, ...rest: SetValueTextArgs<Remote>) {
+  setValue(value: string, ...rest: SetValueTextArgs<Src>) {
     const [text] = rest as [string?];
     const option = this.options.find((o) => o.getAttribute('value') === value);
     const textValue = text || option?.getAttribute('data-text') || '';
@@ -386,7 +395,7 @@ export default class AwcAutocompleteElement<
    * Removes a value from the element.
    * @param value - The value of the option (you do not have to provide the value arg for a single select).
    */
-  removeValue(...args: RemoveValueArgs<Multiple>) {
+  removeValue(...args: RemoveValueArgs<Mode>) {
     const [value] = args as [string?];
     if (this.selectVariant instanceof MultipleSelect && value) {
       this.selectVariant.removeValue(value);
@@ -459,7 +468,7 @@ export default class AwcAutocompleteElement<
     const value = tag.getAttribute('value');
     if (!value) return;
     // Tags only exist in multi-select mode, so the value argument is always required here.
-    (this as AwcAutocompleteElement<true>).removeValue(value);
+    (this as AwcAutocompleteElement<'multiple'>).removeValue(value);
   }
 
   /**
@@ -479,12 +488,12 @@ export default class AwcAutocompleteElement<
   /**
    * Returns the selected value.
    */
-  get value(): AutocompleteValue<Multiple> {
+  get value(): AutocompleteValue<Mode> {
     if (this.multiple) {
-      return this.tags.map((tag) => tag.getAttribute('value') ?? '') as AutocompleteValue<Multiple>;
+      return this.tags.map((tag) => tag.getAttribute('value') ?? '') as AutocompleteValue<Mode>;
     }
     return (this.querySelector<HTMLInputElement>('input[data-behavior="hidden-field"]')?.value ??
-      '') as AutocompleteValue<Multiple>;
+      '') as AutocompleteValue<Mode>;
   }
 
   /**
@@ -523,10 +532,10 @@ export default class AwcAutocompleteElement<
   }
 }
 
-export type SingleAutocompleteElement = AwcAutocompleteElement<false>;
-export type MultipleAutocompleteElement = AwcAutocompleteElement<true>;
-export type LocalAutocompleteElement = AwcAutocompleteElement<boolean, false>;
-export type RemoteAutocompleteElement = AwcAutocompleteElement<boolean, true>;
+export type SingleAutocompleteElement = AwcAutocompleteElement<'single'>;
+export type MultipleAutocompleteElement = AwcAutocompleteElement<'multiple'>;
+export type LocalAutocompleteElement = AwcAutocompleteElement<SelectionMode, 'local'>;
+export type RemoteAutocompleteElement = AwcAutocompleteElement<SelectionMode, 'remote'>;
 
 declare global {
   interface Window {

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -26,6 +26,13 @@ type RemoveValueArgs<Multiple extends boolean> = Multiple extends true ? [value:
 /** Resolves the select variant based on the selection mode. */
 type SelectVariant<Multiple extends boolean> = Multiple extends true ? MultipleSelect : SingleSelect;
 
+/** The contract implemented by the local and remote search variants. */
+export interface SearchVariant {
+  search(value: string): void | Promise<void>;
+  start(): void;
+  stop(): void;
+}
+
 @registerElement('awc-autocomplete')
 export default class AwcAutocompleteElement<Multiple extends boolean = boolean> extends ImpulseElement {
   /**
@@ -81,7 +88,7 @@ export default class AwcAutocompleteElement<Multiple extends boolean = boolean> 
 
   combobox: Combobox;
   selectVariant: SelectVariant<Multiple>;
-  private searchVariant: LocalSearch | RemoteSearch;
+  private searchVariant: SearchVariant;
   private floatingUI: UseFloatingUIType;
   private firstFocus = true;
   private preventOutsideClickEvent = false;

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -26,6 +26,9 @@ export type Source = 'local' | 'remote';
 /** Resolves the runtime `multiple` property type from the selection mode. */
 type IsMultiple<Mode extends SelectionMode> = Mode extends 'multiple' ? true : false;
 
+/** Resolves the runtime `remote` getter type from the source. */
+type IsRemote<Src extends Source> = Src extends 'remote' ? true : false;
+
 /** Resolves the `value` type based on the selection mode. */
 export type AutocompleteValue<Mode extends SelectionMode> = Mode extends 'multiple' ? string[] : string;
 
@@ -486,6 +489,14 @@ export default class AwcAutocompleteElement<
   }
 
   /**
+   * Whether the options are fetched from a remote source (i.e. the `src` attribute is set).
+   * Narrowing on this (`if (el.remote)`) resolves source-dependent types such as `setValue`.
+   */
+  get remote(): IsRemote<Src> {
+    return Boolean(this.src) as IsRemote<Src>;
+  }
+
+  /**
    * Returns the selected value.
    */
   get value(): AutocompleteValue<Mode> {
@@ -548,7 +559,12 @@ declare global {
     AwcAutocompleteElement: typeof AwcAutocompleteElement;
   }
   interface HTMLElementTagNameMap {
-    'awc-autocomplete': SingleAutocompleteElement | MultipleAutocompleteElement;
+    // The full cross-product of both dimensions so `if (el.multiple)` and `if (el.remote)` each narrow.
+    'awc-autocomplete':
+      | SingleAutocompleteElement<'local'>
+      | SingleAutocompleteElement<'remote'>
+      | MultipleAutocompleteElement<'local'>
+      | MultipleAutocompleteElement<'remote'>;
   }
   interface GlobalEventHandlersEventMap {
     'awc-autocomplete:commit': CustomEvent<AwcAutocompleteCommitEvent>;

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -532,10 +532,16 @@ export default class AwcAutocompleteElement<
   }
 }
 
-export type SingleAutocompleteElement = AwcAutocompleteElement<'single'>;
-export type MultipleAutocompleteElement = AwcAutocompleteElement<'multiple'>;
-export type LocalAutocompleteElement = AwcAutocompleteElement<SelectionMode, 'local'>;
-export type RemoteAutocompleteElement = AwcAutocompleteElement<SelectionMode, 'remote'>;
+export type SingleAutocompleteElement<Src extends Source = Source> = AwcAutocompleteElement<'single', Src>;
+export type MultipleAutocompleteElement<Src extends Source = Source> = AwcAutocompleteElement<'multiple', Src>;
+export type LocalAutocompleteElement<Mode extends SelectionMode = SelectionMode> = AwcAutocompleteElement<
+  Mode,
+  'local'
+>;
+export type RemoteAutocompleteElement<Mode extends SelectionMode = SelectionMode> = AwcAutocompleteElement<
+  Mode,
+  'remote'
+>;
 
 declare global {
   interface Window {

--- a/src/elements/autocomplete/index.ts
+++ b/src/elements/autocomplete/index.ts
@@ -23,6 +23,9 @@ export type AutocompleteValue<Multiple extends boolean> = Multiple extends true 
 /** Resolves the `removeValue` arguments: required for multi-select, none for single-select. */
 type RemoveValueArgs<Multiple extends boolean> = Multiple extends true ? [value: string] : [];
 
+/** Resolves the `setValue` text argument: required for a remote source, optional otherwise. */
+type SetValueTextArgs<Remote extends boolean> = Remote extends true ? [text: string] : [text?: string];
+
 /** Resolves the select variant based on the selection mode. */
 type SelectVariant<Multiple extends boolean> = Multiple extends true ? MultipleSelect : SingleSelect;
 
@@ -34,7 +37,10 @@ export interface SearchVariant {
 }
 
 @registerElement('awc-autocomplete')
-export default class AwcAutocompleteElement<Multiple extends boolean = boolean> extends ImpulseElement {
+export default class AwcAutocompleteElement<
+  Multiple extends boolean = boolean,
+  Remote extends boolean = boolean,
+> extends ImpulseElement {
   /**
    * Shows/hides the listbox element.
    */
@@ -369,7 +375,8 @@ export default class AwcAutocompleteElement<Multiple extends boolean = boolean> 
    * @param value - The value of the option.
    * @param text - The text of the option.
    */
-  setValue(value: string, text?: string) {
+  setValue(value: string, ...rest: SetValueTextArgs<Remote>) {
+    const [text] = rest as [string?];
     const option = this.options.find((o) => o.getAttribute('value') === value);
     const textValue = text || option?.getAttribute('data-text') || '';
     this.selectVariant.setValue(value, textValue);
@@ -518,6 +525,8 @@ export default class AwcAutocompleteElement<Multiple extends boolean = boolean> 
 
 export type SingleAutocompleteElement = AwcAutocompleteElement<false>;
 export type MultipleAutocompleteElement = AwcAutocompleteElement<true>;
+export type LocalAutocompleteElement = AwcAutocompleteElement<boolean, false>;
+export type RemoteAutocompleteElement = AwcAutocompleteElement<boolean, true>;
 
 declare global {
   interface Window {

--- a/src/elements/autocomplete/local_search.ts
+++ b/src/elements/autocomplete/local_search.ts
@@ -1,6 +1,7 @@
-import AwcAutocompleteElement from './index';
+import type AwcAutocompleteElement from './index';
+import type { SearchVariant } from './index';
 
-export default class LocalSearch {
+export default class LocalSearch implements SearchVariant {
   readonly autocomplete: AwcAutocompleteElement;
 
   constructor(autocomplete: AwcAutocompleteElement) {

--- a/src/elements/autocomplete/remote_search.ts
+++ b/src/elements/autocomplete/remote_search.ts
@@ -1,7 +1,8 @@
 import debounce from 'src/helpers/debounce';
-import AwcAutocompleteElement from './index';
+import type AwcAutocompleteElement from './index';
+import type { SearchVariant } from './index';
 
-export default class RemoteSearch {
+export default class RemoteSearch implements SearchVariant {
   readonly autocomplete: AwcAutocompleteElement;
   private abortController?: AbortController;
   private cachedOptions: string = '';

--- a/src/elements/autocomplete/single_select.ts
+++ b/src/elements/autocomplete/single_select.ts
@@ -58,7 +58,7 @@ export default class SingleSelect {
   }
 
   private get selectedOption() {
-    return this.autocomplete.options.find((o) => o.getAttribute('value') === this.autocomplete.value);
+    return this.autocomplete.options.find((o) => o.getAttribute('value') === this.hiddenField.value);
   }
 
   private get hiddenField() {


### PR DESCRIPTION
## Summary

Tightens the TypeScript types for `awc-autocomplete` so the selection mode and option source drive the API types, instead of the loose `string | string[]` union that forced consumers to guess.

The class is now generic on two string-literal dimensions:

```ts
AwcAutocompleteElement<Mode extends 'single' | 'multiple', Src extends 'local' | 'remote'>
```

- **`value`** resolves to `string` (single) or `string[]` (multiple).
- **`removeValue`** requires a value arg only for multi-select.
- **`setValue`** requires the `text` arg only for a remote source (the option isn't in the DOM, so its text can't be derived).
- **`selectVariant`** infers `SingleSelect` / `MultipleSelect`.

Two discriminants enable automatic narrowing, and combine:

```ts
const el = document.querySelector('awc-autocomplete')!;
if (el.multiple) { el.value /* string[] */; el.removeValue('1'); }
if (el.remote)   { el.setValue('1', 'One'); /* text required */ }
```

`remote` is a new derived getter (`Boolean(this.src)`) mirroring the boolean `multiple` property. The tag is registered as the full cross-product of both dimensions so each narrows independently.

For consumers that know the shape up front, composable exported aliases are available:

```ts
document.querySelector<MultipleAutocompleteElement<'remote'>>('awc-autocomplete');
```

Also enforces a shared `SearchVariant` contract that `LocalSearch` / `RemoteSearch` implement, and drops a couple of now-unnecessary casts.

## Notes

- The unparameterized type stays the widest/lenient one, so existing untyped consumers and the `string | string[]` reads keep compiling. Strict behavior is opt-in via narrowing or the exported aliases.
- Because the tag map is the 4-way cross-product, the bare `querySelector('awc-autocomplete')` handle requires narrowing `remote` before `setValue` (just as it already required narrowing `multiple` before `removeValue`).

## Verification

- `npx tsc --noEmit`, `yarn lint`, `yarn build:js` — all clean.
- Narrowing verified with `@ts-expect-error` smoke tests (multiple, remote, combined, and the explicit aliases).
- Docs updated in `docs/js-api/autocomplete.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
