### PR TITLE
perf: filter local autocomplete groups in a single pass

### DIFF
--- a/src/elements/autocomplete/local_search.ts
+++ b/src/elements/autocomplete/local_search.ts
@@ -9,7 +9,7 @@ export default class LocalSearch implements SearchVariant {
   }
 
   search(value: string) {
-    this.autocomplete.options.forEach(filterOptions(value));
+    filterOptions(this.autocomplete.options, value);
     const firstOption = this.autocomplete.visibleOptions[0];
     if (firstOption) {
       this.autocomplete.combobox.activate(firstOption);
@@ -37,22 +37,22 @@ export default class LocalSearch implements SearchVariant {
   }
 }
 
-function filterOptions(query: string) {
-  return (option: HTMLElement) => {
+function filterOptions(options: HTMLElement[], query: string) {
+  const normalizedQuery = query.toLowerCase();
+  // Tracks whether each group has at least one visible option. We accumulate this in a single
+  // pass instead of re-querying every group's options per option (which was O(n × group size)).
+  const groupHasVisibleOption = new Map<HTMLElement, boolean>();
+
+  for (const option of options) {
     const group = option.closest<HTMLElement>('[role="group"]');
-    if (query) {
-      const value = option.getAttribute('data-text');
-      const match = value?.toLowerCase().includes(query.toLowerCase());
-      option.hidden = !match;
-      if (group) {
-        const options = Array.from(group.querySelectorAll<HTMLElement>('[role="option"]'));
-        group.hidden = options.every((o) => o.hidden);
-      }
-    } else {
-      option.hidden = false;
-      if (group) {
-        group.hidden = false;
-      }
+    const match = normalizedQuery ? !!option.getAttribute('data-text')?.toLowerCase().includes(normalizedQuery) : true;
+    option.hidden = !match;
+    if (group) {
+      groupHasVisibleOption.set(group, (groupHasVisibleOption.get(group) ?? false) || match);
     }
-  };
+  }
+
+  for (const [group, hasVisibleOption] of groupHasVisibleOption) {
+    group.hidden = !hasVisibleOption;
+  }
 }


### PR DESCRIPTION
## What

`LocalSearch.filterOptions` re-queried every group's options via `querySelectorAll` for each option that belonged to a group, making local filtering **O(n × group size)** per keystroke. This accumulates per-group visibility in a single `Map` pass instead, then sets each group's `hidden` flag once.

## Why

On large grouped local autocompletes, the nested `querySelectorAll` + `.every()` per option added avoidable work on every keystroke. The new single-pass approach is linear in the number of options.

## Behaviour

Unchanged. The observable result — `hidden` flags on options and groups — is identical:
- An option is hidden when its `data-text` doesn't match the query.
- A group is hidden when all of its options are hidden.
- Empty query shows everything.

## Testing

- `yarn build` and `yarn lint` pass
- `test/system/autocomplete_test.rb` — 12 runs, 52 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)