### PR TITLE
fix: point exports subpaths at files instead of directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,20 @@ jobs:
           yarn install --frozen-lockfile
           yarn lint
 
+  check_exports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".tool-versions"
+          cache: "yarn"
+      - name: Check package exports
+        run: |
+          yarn install --frozen-lockfile
+          NODE_ENV=production yarn build:js
+          yarn test:exports
+
   lint_ruby:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed the `exports` subpath map pointing at directories instead of files, which broke `dist/elements/*`, `dist/hooks/*` and `dist/helpers/*` imports for Node and for TypeScript under `moduleResolution: bundler`/`node16`. Every subpath now maps to a real file and declares a `types` condition, and element stylesheets stay reachable through the `sass`/`style` conditions ([#224](https://github.com/Ambiki/impulse_view_components/issues/224))
 - Fixed `useOutsideClick` leaking its `click` listener by switching teardown to `AbortController` ([#215](https://github.com/Ambiki/impulse_view_components/pull/215))
 
 ## [0.8.0] - 2026-01-09

--- a/package.json
+++ b/package.json
@@ -22,11 +22,60 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
-    "./dist/elements/*": "./dist/elements/*",
-    "./dist/hooks/*": "./dist/hooks/*",
-    "./dist/helpers/*": "./dist/helpers/*",
+    "./package.json": "./package.json",
+    "./dist/index.js": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./dist/elements/anchor": {
+      "types": "./dist/elements/anchor/index.d.ts",
+      "default": "./dist/elements/anchor/index.js"
+    },
+    "./dist/elements/autocomplete": {
+      "types": "./dist/elements/autocomplete/index.d.ts",
+      "sass": "./dist/elements/autocomplete/index.scss",
+      "style": "./dist/elements/autocomplete/index.scss",
+      "default": "./dist/elements/autocomplete/index.js"
+    },
+    "./dist/elements/dialog": {
+      "types": "./dist/elements/dialog/index.d.ts",
+      "sass": "./dist/elements/dialog/index.scss",
+      "style": "./dist/elements/dialog/index.scss",
+      "default": "./dist/elements/dialog/index.js"
+    },
+    "./dist/elements/popover": {
+      "types": "./dist/elements/popover/index.d.ts",
+      "sass": "./dist/elements/popover/index.scss",
+      "style": "./dist/elements/popover/index.scss",
+      "default": "./dist/elements/popover/index.js"
+    },
+    "./dist/elements/*.scss": "./dist/elements/*.scss",
+    "./dist/elements/*.js": {
+      "types": "./dist/elements/*.d.ts",
+      "default": "./dist/elements/*.js"
+    },
+    "./dist/elements/*": {
+      "types": "./dist/elements/*.d.ts",
+      "default": "./dist/elements/*.js"
+    },
+    "./dist/hooks/*.js": {
+      "types": "./dist/hooks/*.d.ts",
+      "default": "./dist/hooks/*.js"
+    },
+    "./dist/hooks/*": {
+      "types": "./dist/hooks/*.d.ts",
+      "default": "./dist/hooks/*.js"
+    },
+    "./dist/helpers/*.js": {
+      "types": "./dist/helpers/*.d.ts",
+      "default": "./dist/helpers/*.js"
+    },
+    "./dist/helpers/*": {
+      "types": "./dist/helpers/*.d.ts",
+      "default": "./dist/helpers/*.js"
+    },
     "./dist/styles/*": "./dist/styles/*"
   },
   "files": [
@@ -53,6 +102,7 @@
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "test": "web-test-runner",
+    "test:exports": "node scripts/check-exports.mjs",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {

--- a/scripts/check-exports.mjs
+++ b/scripts/check-exports.mjs
@@ -6,17 +6,23 @@
 // `mainFiles` *after* the exports mapping), so a broken map only surfaces in Node and in
 // TypeScript once a consumer moves to `moduleResolution: bundler`/`node16`.
 //
-// This script therefore checks resolution the way those two resolvers do:
+// This script therefore checks resolution the way those resolvers do:
 //   1. every public subpath resolves through Node's ESM resolver to a file that exists,
-//   2. every element directory is reachable by its bare specifier, with its stylesheet
-//      exposed under the `sass`/`style` conditions,
-//   3. `tsc --noEmit` passes on a fixture that imports all of them.
+//   2. element stylesheets resolve under the `sass`/`style` conditions, which is how
+//      sass-loader asks for them,
+//   3. a declaration file sits next to every runtime file,
+//   4. `tsc --noEmit` passes on a fixture that imports all of them.
+//
+// Resolution works without linking the package into `node_modules`: a package with an
+// `exports` map can reference itself by name, and both this script and the fixture live
+// inside it.
 //
 // Run with `yarn test:exports` (requires `NODE_ENV=production yarn build:js` first).
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -34,23 +40,22 @@ function check(description, fn) {
   }
 }
 
-// Node only resolves a package by name from a `node_modules` directory, so link the package
-// into its own tree. `node_modules` is gitignored, and the link is reused across runs.
-function linkSelf() {
-  const linkPath = path.join(rootDir, 'node_modules', pkg.name);
-  fs.mkdirSync(path.dirname(linkPath), { recursive: true });
-
-  if (fs.existsSync(linkPath)) {
-    if (fs.realpathSync(linkPath) === fs.realpathSync(rootDir)) return;
-    fs.rmSync(linkPath, { recursive: true, force: true });
-  }
-
-  fs.symlinkSync(rootDir, linkPath, 'junction');
+function resolvesToFile(specifier) {
+  const filePath = fileURLToPath(import.meta.resolve(specifier));
+  assert.ok(fs.existsSync(filePath), `resolved to ${path.relative(rootDir, filePath)}, which does not exist`);
+  return filePath;
 }
 
-function resolvesToFile(specifier) {
-  const resolved = import.meta.resolve(specifier);
-  const filePath = fileURLToPath(resolved);
+// `import.meta.resolve` cannot be given custom conditions, so resolve in a child process
+// that was started with them.
+function resolvesToFileUnder(conditions, specifier) {
+  const script = `process.stdout.write(import.meta.resolve(${JSON.stringify(specifier)}))`;
+  const args = [...conditions.flatMap((condition) => ['--conditions', condition]), '--input-type=module', '-e', script];
+  const result = spawnSync(process.execPath, args, { cwd: rootDir, encoding: 'utf8' });
+
+  assert.equal(result.status, 0, `did not resolve\n${(result.stderr || '').trim()}`);
+
+  const filePath = fileURLToPath(result.stdout.trim());
   assert.ok(fs.existsSync(filePath), `resolved to ${path.relative(rootDir, filePath)}, which does not exist`);
   return filePath;
 }
@@ -66,13 +71,14 @@ if (!fs.existsSync(distDir) || !fs.existsSync(path.join(distDir, 'styles'))) {
   process.exit(1);
 }
 
-linkSelf();
-
-// 1. Runtime resolution through Node's ESM resolver.
 const elementDirs = fs
   .readdirSync(path.join(distDir, 'elements'), { withFileTypes: true })
   .filter((entry) => entry.isDirectory())
   .map((entry) => entry.name);
+
+const styledElementDirs = elementDirs.filter((name) =>
+  fs.existsSync(path.join(distDir, 'elements', name, 'index.scss'))
+);
 
 const flatModules = ['hooks', 'helpers'].flatMap((group) =>
   fs
@@ -81,7 +87,8 @@ const flatModules = ['hooks', 'helpers'].flatMap((group) =>
     .map((file) => [group, path.basename(file, '.js')])
 );
 
-const specifiers = [
+// 1. Runtime resolution through Node's ESM resolver.
+const scriptSpecifiers = [
   pkg.name,
   subpath('dist', 'index.js'),
   ...elementDirs.map((name) => subpath('dist', 'elements', name)),
@@ -93,34 +100,45 @@ const specifiers = [
     .readdirSync(path.join(distDir, 'elements', 'autocomplete'))
     .filter((file) => file.endsWith('.js') && file !== 'index.js')
     .map((file) => subpath('dist', 'elements', 'autocomplete', path.basename(file, '.js'))),
-  // Stylesheets are addressed with their extension.
+];
+
+// Stylesheets addressed with their extension, which needs no condition.
+const styleSpecifiers = [
+  ...styledElementDirs.map((name) => subpath('dist', 'elements', name, 'index.scss')),
   ...fs.readdirSync(path.join(distDir, 'styles')).map((file) => subpath('dist', 'styles', file)),
 ];
 
-for (const specifier of specifiers) {
+for (const specifier of [...scriptSpecifiers, ...styleSpecifiers]) {
   check(`node: ${specifier}`, () => resolvesToFile(specifier));
 }
 
-// 2. Types and stylesheet conditions declared for every element directory.
+// 2. Element stylesheets under the conditions sass-loader resolves with. Without them the
+// bare specifier lands on the element's JavaScript, and sass-loader reports the subpath as
+// missing rather than falling back.
+for (const name of styledElementDirs) {
+  const specifier = subpath('dist', 'elements', name);
+  const stylesheet = path.join(distDir, 'elements', name, 'index.scss');
+
+  for (const condition of ['sass', 'style']) {
+    check(`node --conditions ${condition}: ${specifier}`, () => {
+      assert.equal(resolvesToFileUnder([condition], specifier), stylesheet);
+    });
+  }
+}
+
+// Element directories need an exact key: a pattern cannot append `/index`, so a new element
+// silently stops resolving without one.
 for (const name of elementDirs) {
   const key = `./dist/elements/${name}`;
 
   check(`exports["${key}"]`, () => {
-    const entry = pkg.exports[key];
-    assert.ok(entry, `missing. Element directories need an exact key: patterns cannot add /index`);
-    assert.equal(entry.types, `${key}/index.d.ts`);
-    assert.equal(entry.default, `${key}/index.js`);
-
-    if (fs.existsSync(path.join(rootDir, key, 'index.scss'))) {
-      assert.equal(entry.sass, `${key}/index.scss`, 'stylesheet not exposed under the `sass` condition');
-      assert.equal(entry.style, `${key}/index.scss`, 'stylesheet not exposed under the `style` condition');
-    }
+    assert.ok(pkg.exports[key], 'missing. Element directories need an exact key, patterns cannot append /index');
   });
 }
 
-// Types must resolve alongside every runtime file, otherwise `tsc` reports TS2307 even
+// 3. Types must resolve alongside every runtime file, otherwise `tsc` reports TS2307 even
 // though Node is happy.
-for (const specifier of specifiers.filter((value) => !value.endsWith('.scss'))) {
+for (const specifier of scriptSpecifiers) {
   check(`types: ${specifier}`, () => {
     const filePath = resolvesToFile(specifier);
     const types = filePath.replace(/\.js$/, '.d.ts');
@@ -128,9 +146,9 @@ for (const specifier of specifiers.filter((value) => !value.endsWith('.scss'))) 
   });
 }
 
-// 3. A consumer type-checking under both exports-aware resolution modes.
+// 4. A consumer type-checking under both exports-aware resolution modes.
 const fixture = path.join(rootDir, 'scripts', 'exports-fixture', 'tsconfig.json');
-const tscBin = path.join(rootDir, 'node_modules', 'typescript', 'bin', 'tsc');
+const tscBin = createRequire(import.meta.url).resolve('typescript/bin/tsc');
 
 for (const [moduleKind, moduleResolution] of [
   ['ESNext', 'bundler'],
@@ -150,4 +168,5 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`✓ ${specifiers.length} subpaths resolve in Node and type-check under moduleResolution bundler/node16`);
+const total = scriptSpecifiers.length + styleSpecifiers.length;
+console.log(`✓ ${total} subpaths resolve in Node and type-check under moduleResolution bundler/node16`);

--- a/scripts/check-exports.mjs
+++ b/scripts/check-exports.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Consumer-shaped smoke check for the `exports` map in package.json.
+//
+// Subpath patterns are substituted literally: there is no extension probing and no
+// directory-index lookup. Bundlers hide that (webpack applies `resolve.extensions` and
+// `mainFiles` *after* the exports mapping), so a broken map only surfaces in Node and in
+// TypeScript once a consumer moves to `moduleResolution: bundler`/`node16`.
+//
+// This script therefore checks resolution the way those two resolvers do:
+//   1. every public subpath resolves through Node's ESM resolver to a file that exists,
+//   2. every element directory is reachable by its bare specifier, with its stylesheet
+//      exposed under the `sass`/`style` conditions,
+//   3. `tsc --noEmit` passes on a fixture that imports all of them.
+//
+// Run with `yarn test:exports` (requires `NODE_ENV=production yarn build:js` first).
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+const distDir = path.join(rootDir, 'dist');
+const failures = [];
+
+function check(description, fn) {
+  try {
+    fn();
+  } catch (error) {
+    failures.push(`${description}\n    ${error.message.split('\n').join('\n    ')}`);
+  }
+}
+
+// Node only resolves a package by name from a `node_modules` directory, so link the package
+// into its own tree. `node_modules` is gitignored, and the link is reused across runs.
+function linkSelf() {
+  const linkPath = path.join(rootDir, 'node_modules', pkg.name);
+  fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+
+  if (fs.existsSync(linkPath)) {
+    if (fs.realpathSync(linkPath) === fs.realpathSync(rootDir)) return;
+    fs.rmSync(linkPath, { recursive: true, force: true });
+  }
+
+  fs.symlinkSync(rootDir, linkPath, 'junction');
+}
+
+function resolvesToFile(specifier) {
+  const resolved = import.meta.resolve(specifier);
+  const filePath = fileURLToPath(resolved);
+  assert.ok(fs.existsSync(filePath), `resolved to ${path.relative(rootDir, filePath)}, which does not exist`);
+  return filePath;
+}
+
+function subpath(...segments) {
+  return [pkg.name, ...segments].join('/');
+}
+
+// Stylesheets are only copied into dist/ by the production build, and they are part of the
+// published surface, so the check needs that build rather than the development one.
+if (!fs.existsSync(distDir) || !fs.existsSync(path.join(distDir, 'styles'))) {
+  console.error('dist/ is missing or incomplete. Run `NODE_ENV=production yarn build:js` before `yarn test:exports`.');
+  process.exit(1);
+}
+
+linkSelf();
+
+// 1. Runtime resolution through Node's ESM resolver.
+const elementDirs = fs
+  .readdirSync(path.join(distDir, 'elements'), { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+const flatModules = ['hooks', 'helpers'].flatMap((group) =>
+  fs
+    .readdirSync(path.join(distDir, group))
+    .filter((file) => file.endsWith('.js'))
+    .map((file) => [group, path.basename(file, '.js')])
+);
+
+const specifiers = [
+  pkg.name,
+  subpath('dist', 'index.js'),
+  ...elementDirs.map((name) => subpath('dist', 'elements', name)),
+  ...elementDirs.map((name) => subpath('dist', 'elements', name, 'index.js')),
+  ...flatModules.map(([group, name]) => subpath('dist', group, name)),
+  ...flatModules.map(([group, name]) => subpath('dist', group, `${name}.js`)),
+  // Non-index modules inside an element directory.
+  ...fs
+    .readdirSync(path.join(distDir, 'elements', 'autocomplete'))
+    .filter((file) => file.endsWith('.js') && file !== 'index.js')
+    .map((file) => subpath('dist', 'elements', 'autocomplete', path.basename(file, '.js'))),
+  // Stylesheets are addressed with their extension.
+  ...fs.readdirSync(path.join(distDir, 'styles')).map((file) => subpath('dist', 'styles', file)),
+];
+
+for (const specifier of specifiers) {
+  check(`node: ${specifier}`, () => resolvesToFile(specifier));
+}
+
+// 2. Types and stylesheet conditions declared for every element directory.
+for (const name of elementDirs) {
+  const key = `./dist/elements/${name}`;
+
+  check(`exports["${key}"]`, () => {
+    const entry = pkg.exports[key];
+    assert.ok(entry, `missing. Element directories need an exact key: patterns cannot add /index`);
+    assert.equal(entry.types, `${key}/index.d.ts`);
+    assert.equal(entry.default, `${key}/index.js`);
+
+    if (fs.existsSync(path.join(rootDir, key, 'index.scss'))) {
+      assert.equal(entry.sass, `${key}/index.scss`, 'stylesheet not exposed under the `sass` condition');
+      assert.equal(entry.style, `${key}/index.scss`, 'stylesheet not exposed under the `style` condition');
+    }
+  });
+}
+
+// Types must resolve alongside every runtime file, otherwise `tsc` reports TS2307 even
+// though Node is happy.
+for (const specifier of specifiers.filter((value) => !value.endsWith('.scss'))) {
+  check(`types: ${specifier}`, () => {
+    const filePath = resolvesToFile(specifier);
+    const types = filePath.replace(/\.js$/, '.d.ts');
+    assert.ok(fs.existsSync(types), `no declaration file next to ${path.relative(rootDir, filePath)}`);
+  });
+}
+
+// 3. A consumer type-checking under both exports-aware resolution modes.
+const fixture = path.join(rootDir, 'scripts', 'exports-fixture', 'tsconfig.json');
+const tscBin = path.join(rootDir, 'node_modules', 'typescript', 'bin', 'tsc');
+
+for (const [moduleKind, moduleResolution] of [
+  ['ESNext', 'bundler'],
+  ['node16', 'node16'],
+]) {
+  const args = ['--noEmit', '-p', fixture, '--module', moduleKind, '--moduleResolution', moduleResolution];
+  const tsc = spawnSync(process.execPath, [tscBin, ...args], { cwd: rootDir, encoding: 'utf8' });
+
+  if (tsc.status !== 0) {
+    failures.push(`tsc ${args.join(' ')}\n    ${(tsc.stdout || tsc.stderr).trim().split('\n').join('\n    ')}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} exports check(s) failed:\n`);
+  for (const failure of failures) console.error(`  ✗ ${failure}\n`);
+  process.exit(1);
+}
+
+console.log(`✓ ${specifiers.length} subpaths resolve in Node and type-check under moduleResolution bundler/node16`);

--- a/scripts/exports-fixture/consumer.ts
+++ b/scripts/exports-fixture/consumer.ts
@@ -1,0 +1,72 @@
+// A consumer-shaped fixture: every public subpath of the package, imported the way an
+// application would import it. Type-checked with `moduleResolution: bundler` and `node16`,
+// both of which honour the `exports` map, so a subpath that stops resolving fails here with
+// TS2307.
+//
+// Every import binds a name on purpose. TypeScript does not report TS2307 for side-effect
+// imports (`import 'pkg/subpath';`), so a bare side-effect import would let a broken subpath
+// through unnoticed.
+//
+// See `scripts/check-exports.mjs`.
+
+import * as root from '@ambiki/impulse-view-components';
+import * as rootIndex from '@ambiki/impulse-view-components/dist/index.js';
+
+import * as anchor from '@ambiki/impulse-view-components/dist/elements/anchor';
+import * as autocomplete from '@ambiki/impulse-view-components/dist/elements/autocomplete';
+import * as dialog from '@ambiki/impulse-view-components/dist/elements/dialog';
+import * as popover from '@ambiki/impulse-view-components/dist/elements/popover';
+
+// Explicit `index.js` form kept working for consumers that adopted it as a workaround.
+import * as autocompleteIndex from '@ambiki/impulse-view-components/dist/elements/autocomplete/index.js';
+
+// Addressable non-index modules inside an element directory.
+import * as localSearch from '@ambiki/impulse-view-components/dist/elements/autocomplete/local_search';
+import * as multipleSelect from '@ambiki/impulse-view-components/dist/elements/autocomplete/multiple_select';
+import * as remoteSearch from '@ambiki/impulse-view-components/dist/elements/autocomplete/remote_search';
+import * as singleSelect from '@ambiki/impulse-view-components/dist/elements/autocomplete/single_select';
+
+import useFloatingUI from '@ambiki/impulse-view-components/dist/hooks/use_floating_ui';
+import useOutsideClick from '@ambiki/impulse-view-components/dist/hooks/use_outside_click';
+
+import { isLooselyFocusable } from '@ambiki/impulse-view-components/dist/helpers/focus';
+import * as array from '@ambiki/impulse-view-components/dist/helpers/array';
+import * as debounce from '@ambiki/impulse-view-components/dist/helpers/debounce';
+import * as focusTrap from '@ambiki/impulse-view-components/dist/helpers/focus_trap';
+import * as scrollLock from '@ambiki/impulse-view-components/dist/helpers/scroll_lock';
+import * as string from '@ambiki/impulse-view-components/dist/helpers/string';
+import * as uniqueId from '@ambiki/impulse-view-components/dist/helpers/unique_id';
+
+// Types must come through the `types` condition, not just the runtime file.
+import type AmbikiAutocompleteElement from '@ambiki/impulse-view-components/dist/elements/autocomplete';
+import type AmbikiDialogElement from '@ambiki/impulse-view-components/dist/elements/dialog';
+import type AmbikiPopoverElement from '@ambiki/impulse-view-components/dist/elements/popover';
+
+export const used = {
+  root,
+  rootIndex,
+  anchor,
+  autocomplete,
+  autocompleteIndex,
+  dialog,
+  popover,
+  localSearch,
+  multipleSelect,
+  remoteSearch,
+  singleSelect,
+  useFloatingUI,
+  useOutsideClick,
+  isLooselyFocusable,
+  array,
+  debounce,
+  focusTrap,
+  scrollLock,
+  string,
+  uniqueId,
+};
+
+export type Elements = {
+  autocomplete: AmbikiAutocompleteElement;
+  dialog: AmbikiDialogElement;
+  popover: AmbikiPopoverElement;
+};

--- a/scripts/exports-fixture/tsconfig.json
+++ b/scripts/exports-fixture/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2017", "dom", "dom.iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2017",
+    "types": []
+  },
+  "include": ["consumer.ts"]
+}


### PR DESCRIPTION
Fixes #224

## Problem

The subpath entries in `exports` mapped to directories. Subpath patterns are substituted **literally** — no extension probing, no directory-index lookup, and no `types` condition — so every `dist/elements/*`, `dist/hooks/*` and `dist/helpers/*` import failed to resolve in Node and in TypeScript under `moduleResolution: bundler`/`node16`:

```
error TS2307: Cannot find module '@ambiki/impulse-view-components/dist/elements/autocomplete' or its corresponding type declarations.
```

It went unnoticed because webpack applies `resolve.extensions` and `mainFiles` *after* the exports mapping, and TypeScript's legacy `moduleResolution: node` ignores `exports` entirely.

## Changes

**`package.json`**

- `./dist/elements/anchor|autocomplete|dialog|popover` — exact keys, since a pattern cannot append `/index`. Each maps `types` to `index.d.ts` and `default` to `index.js`.
- The three elements that ship a stylesheet also expose it under the `sass` and `style` conditions, so `@import '~@ambiki/impulse-view-components/dist/elements/dialog'` keeps resolving. sass-loader supplies those conditions itself (`conditionNames: ['sass', 'style', '...']`), so consumers need no extra webpack config.
- `./dist/elements/*.scss` for stylesheets addressed by extension.
- `./dist/{elements,hooks,helpers}/*` and the matching `*.js` keys point at real files with a `types` condition, covering both the bare specifier and the explicit `.js` form that consumers adopted as a workaround. This also keeps the non-index modules inside `dist/elements/autocomplete/` (`local_search`, `multiple_select`, `remote_search`, `single_select`) addressable.
- `.` now uses `default` rather than `import`; added `./package.json` and `./dist/index.js`.

Exact keys beat patterns, and among patterns with the same prefix the longer key wins, so the `*.js` and `*.scss` keys sort ahead of the bare `*` in both Node's `patternKeyCompare` and TypeScript's longest-pattern match. Declaration order is not load-bearing; the keys are still written specific-first for readability.

**Regression guard — `yarn test:exports`**

`scripts/check-exports.mjs` plus a consumer fixture in `scripts/exports-fixture/`, wired into CI as a `check_exports` job:

1. Every public subpath resolves through Node's ESM resolver to a file that exists. The 37 specifiers are enumerated from `dist/`, not hardcoded.
2. Element stylesheets resolve under the `sass` and `style` conditions. `import.meta.resolve` cannot be given custom conditions, so this resolves in a child process started with them.
3. Every element directory has an exact exports key, so a new element without one fails the check.
4. A declaration file sits next to every runtime file.
5. `tsc --noEmit` on the fixture under **both** `moduleResolution: bundler` and `node16`.

The fixture binds a name on every import on purpose: TypeScript does not report TS2307 for side-effect imports, so `import 'pkg/subpath';` would have let a broken subpath through unnoticed.

The check needs stylesheets in `dist/`, which only the production build copies, so CI runs `NODE_ENV=production yarn build:js` first. Nothing is linked into `node_modules` — a package with an `exports` map can reference itself by name.

## Verification

- Against the old exports map: 34 Node resolution failures plus TS2307 from both TypeScript resolvers.
- Against this branch, from a clean `NODE_ENV=production yarn build:js`: all 37 subpaths resolve and both type-checks pass.
- The sass path was checked end to end against a real webpack + sass-loader build. `@import '~@ambiki/impulse-view-components/dist/elements/autocomplete'` resolves to `dist/elements/autocomplete/index.scss`; dropping the `sass`/`style` conditions turns it into `Can't find stylesheet to import` rather than a silent fallback to the JavaScript file, because sass-loader restricts that resolver to `.sass`/`.scss`/`.css`.
- Negative tests: injecting a bogus subpath into the fixture, dropping an element's exact key, dropping `./dist/elements/*.scss`, and dropping the `sass`/`style` conditions each fail the check as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)